### PR TITLE
Updates Travis to only run on PR into master

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,10 @@ python:
 before_install:
   - make build
 
+branches:
+  only:
+    - master
+
 install:
   - pip install -r requirements-develop.txt
   - python setup.py develop


### PR DESCRIPTION
- Current run time on a Travis check is over 7 minutes
- With a PR into master this will be run twice, requiring almost 15 minutes before it can be merged
- With this change it would only run the tests on the branch into master, removing 1 of the 2 tests of the same code (usually)
- Can also expand to have when PR to a second branch, such as a devel branch, if one is created in the future
