### PR TITLE
Remove full arg in get_config to align with Napalm 2.4.0

### DIFF
--- a/network_importer/tasks.py
+++ b/network_importer/tasks.py
@@ -336,9 +336,7 @@ def update_configuration(  # pylint: disable=C0330
         previous_md5 = hashlib.md5(current_config.encode("utf-8")).hexdigest()
 
     try:
-        results = task.run(
-            task=napalm_get, getters=["config"], retrieve="running"
-        )
+        results = task.run(task=napalm_get, getters=["config"], retrieve="running")
     except:
         logger.debug(
             "An exception occured while pulling the configuration", exc_info=True


### PR DESCRIPTION
The new version of Netmiko and Nornir introduced a strange dependencies conflicts between Napalm, Nornir and Netmiko.
As a result, Napalm got downgraded to 2.4.0 (vs 2.5.0) by Poetry. 

In 2.4. the option argument `full` is not supported in `get_config`, since this argument is not used anymore I removed it

The requirements for Napalm have been updated in Github to support the new version of Netmiko but this has not been released yet. We could install napalm from Github directy but for now I think we good with 2.4. We can revisit this decision later as we identify missing features in 2.4
