### PR TITLE
Removing 3.6 from Travis for now

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 python:
-  - 3.6
   - 3.7
 
 before_install:


### PR DESCRIPTION
Right now we have 3.6 and 3.7 in the config file for travis but it's not really sueful because we have hardcoded the version of python in the dockerfile.

This PR is removing 3.6 from the travic config for now and we need to refactor the Dockerfile and the Makefile to properly build based on the version defined in travis