### PR TITLE
Change default interface type for Netbox 2.6 and 2.7 to other 

### DIFF
--- a/network_importer/remote/netbox.py
+++ b/network_importer/remote/netbox.py
@@ -141,20 +141,8 @@ class Netbox26Interface(NetboxInterface):
             intf_properties["type"] = 200
         elif intf.is_virtual:
             intf_properties["type"] = 0
-        elif intf.speed == 1000000000:
-            intf_properties["type"] = 800
-        elif intf.speed == 1000000000:
-            intf_properties["type"] = 1100
-        elif intf.speed == 10000000000:
-            intf_properties["type"] = 1200
-        elif intf.speed == 25000000000:
-            intf_properties["type"] = 1350
-        elif intf.speed == 40000000000:
-            intf_properties["type"] = 1400
-        elif intf.speed == 100000000000:
-            intf_properties["type"] = 1600
         else:
-            intf_properties["type"] = 1100
+            intf_properties["type"] = 32767
 
         if intf.mtu:
             intf_properties["mtu"] = intf.mtu
@@ -260,7 +248,7 @@ class Netbox27Interface(NetboxInterface):
         elif intf.is_virtual:
             intf_properties["type"] = "virtual"
         else:
-            intf_properties["type"] = "10gbase-x-sfpp"
+            intf_properties["type"] = "other"
 
         if intf.mtu:
             intf_properties["mtu"] = intf.mtu


### PR DESCRIPTION
Currently if an interface doesn't exist in NetBox and is not a Lag or a Virtual interface network Importer is either setting the device type to `10gbase-x-sfpp` by default (NetBox 2.7+) or is trying to determine the type of the interface based on its speed.(NetBox 2.6)
Neither solution is really good and as a result it's creating misleading interface type in NetBox

This PR is changing the default interface type to "Other" for both NetBox 2.7 and Netbox 2.6 when an interface do not exist already in NetBox and when it's neither a virtual interface nor a lag  