### PR TITLE
Add cleaner error message when the configuration file is not valid

### DIFF
--- a/network_importer/config.py
+++ b/network_importer/config.py
@@ -161,7 +161,7 @@ def load_config(config_file_name=None, config_data=None):
     v = config_validator(schema.config_schema)
     config_errors = sorted(v.iter_errors(config), key=str)
 
-    if len(config_errors) is not 0:
+    if len(config_errors) != 0:
         print(
             f"Found {len(config_errors)} error(s) in the configuration file ({config_file_name})"
         )


### PR DESCRIPTION
Currently if the configuration file is not compliant with the schema defined in `schema.py`, we are raising an exception and the error message is not super clean.
Also if the configuration file contains multiple error, an exception will be raised on the first one and the other error will be ignored.

This PR improves the validation of the config file and will create a clean error message for all error in the configuration file.

```
# network-importer --check --diff
Found 2 error(s) in the configuration file (network_importer.toml)
  False is not of type 'string' in main/backend_type
  False is not one of ['netbox'] in main/backend_type
```
