### PR TITLE
Fix vlan prefix-mapping when hostname include some uppercase letters

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -326,7 +326,7 @@ class NetworkImporter:
 
                     # Save interface to vlan mapping for later use
                     for intf in vlan.Interfaces:
-                        if intf.hostname != dev.name:
+                        if intf.hostname != dev.name.lower():
                             continue
                         interface_vlans_mapping[intf.interface].append(vlan.VLAN_ID)
 


### PR DESCRIPTION
In few cases, devices name in Batfish are all lowercase even if the hostname include some uppercase. 
