### PR TITLE
Improve vlan cli handling

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -905,9 +905,7 @@ class NetworkImporter:
                 self.devs.inventory.hosts[dev_name].data["status"] = "fail-other"
                 continue
             elif not items[0].result:
-                logger.warning(
-                    f"{dev_name} | No VLAN results returned."
-                )
+                logger.warning(f"{dev_name} | No VLAN results returned.")
                 continue
             else:
                 for vlan in items[0].result:
@@ -919,7 +917,8 @@ class NetworkImporter:
                     ):
 
                         self.devs.inventory.hosts[dev_name].data["obj"].site.add_vlan(
-                            vlan=Vlan(name=vlan["name"], vid=vlan["id"]), device=dev_name,
+                            vlan=Vlan(name=vlan["name"], vid=vlan["id"]),
+                            device=dev_name,
                         )
 
     # --------------------------------------------------------------------------

--- a/network_importer/tasks.py
+++ b/network_importer/tasks.py
@@ -299,7 +299,9 @@ def collect_vlans_info(task: Task, update_cache=True, use_cache=False) -> Result
             vlans.append(dict(name=data["name"], id=vid))
 
     else:
-        logger.warning(f"{task.host.name} | Unable to collect VLAN information via cmd - Unsupported device type {task.host.platform}")
+        logger.warning(
+            f"{task.host.name} | Unable to collect VLAN information via cmd - Unsupported device type {task.host.platform}"
+        )
 
     if update_cache and results:
         save_data_to_file(task.host.name, cache_name, vlans)


### PR DESCRIPTION
This PR looks to improve the handling of collecting VLANs from devices via the CLI. Main fixes include:
* Prior to this fix an exception would be raised in the event of VLAN collection to an unknown device type (i.e devices other then eos, nxos, ios).  
* Fix naming of device types. For example `ios` -> `cisco_ios`.