### PR TITLE
Feature/prefix vlan cli

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -316,7 +316,7 @@ class NetworkImporter:
             # Discover the vlans on the devices, and extract the interface to vlans mapping
             # if the vlans should be imported from the configuration, create them in the site object.
 
-            if config.main["import_vlans"] != False:
+            if config.main["import_vlans"]:
                 bf_vlans = self.bf.q.switchedVlanProperties(nodes=dev.name).answer()
                 for vlan in bf_vlans.frame().itertuples():
                     if config.main["import_vlans"] == "config":

--- a/network_importer/model.py
+++ b/network_importer/model.py
@@ -508,7 +508,7 @@ class NetworkImporterDevice:
                 ]
 
     def import_local_prefix(self):
-        for intf_name in self.interfaces.keys():
+        for intf_name, intf_values in self.interfaces.items():
             for ip_address, ip in self.interfaces[intf_name].ips.items():
                 if not ip.local:
                     continue


### PR DESCRIPTION
When using the configuration option `import_vlans = "cli"`, this PR adds support for the following, 
* Prefix to VLAN mapping.
* Detection of the encaps VLAN if the interface is an L3 sub-interface.
