### PR TITLE
Improve error handling for pvlans

### DIFF
--- a/network_importer/tasks.py
+++ b/network_importer/tasks.py
@@ -283,7 +283,10 @@ def collect_vlans_info(task: Task, update_cache=True, use_cache=False) -> Result
             return Result(host=task.host, result=False)
 
         for vid, data in results[0].result["vlans"].items():
-            vlans.append(dict(name=data["name"], id=data["vlan_id"]))
+            if not data.get("name", None):
+                logger.warning(f"{task.host.name} | Unknown VLAN data, VLAN {vid}")
+            else:
+                vlans.append(dict(name=data["name"], id=data["vlan_id"]))
 
     elif task.host.platform == "eos":
 


### PR DESCRIPTION
Currently, if a PVLAN is returned for a `ios` or `nxos` device, there is no `name` key within the returned `dict()`. This results in a `KeyError`. This PR improves error handling when private VLANs are returned.