### PR TITLE
allow filter with multiple occurrences of the same field

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -146,7 +146,13 @@ class NetworkImporter:
                     continue
 
                 key, value = csp.split("=", 1)
-                params[key] = value
+                existing_value = params.get(key)
+                if existing_value and isinstance(existing_value, list):
+                    params[key].append(value)
+                elif existing_value and isinstance(existing_value, str):
+                    params[key] = [existing_value, value]
+                else:
+                    params[key] = value
 
         if limit:
             if "=" not in limit:


### PR DESCRIPTION
NetBox REST API and pynetbox allow multiple occurrences of the same field for filtering, leading to a logical OR relation.

Examples:
- `role=router,role=switch` which filters for devices with the router or switch role
- `region=country,role=router,role=switch` which filters for devices in region country with the router or switch role.