### PR TITLE
Add logic to prevent unsupported vlan additions

### DIFF
--- a/network_importer/tasks.py
+++ b/network_importer/tasks.py
@@ -285,6 +285,8 @@ def collect_vlans_info(task: Task, update_cache=True, use_cache=False) -> Result
         for vid, data in results[0].result["vlans"].items():
             if not data.get("name", None):
                 logger.warning(f"{task.host.name} | Unknown VLAN data, VLAN {vid}")
+            if data.get("state", None) == "unsupport":
+                logger.warning(f"{task.host.name} | Unsupported VLAN found, VLAN {vid}")
             else:
                 vlans.append(dict(name=data["name"], id=data["vlan_id"]))
 


### PR DESCRIPTION
Prior to this PR, if the VLANs are learned via CLI, i.e the VLAN database, internal/unsupported VLANs for certain devices would still be seen and added as a local VLAN within the network-importer models.
This PR prevents this by checking if the VLAN is of an `unsupported` status. If so then it is not added. *Note*: This change only affects IOS and NXOS based devices.
