### PR TITLE
Negate init on unreachable

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -251,7 +251,9 @@ class NetworkImporter:
         #  - Create NID object
         #  - Pull cache information from Netbox
         # --------------------------------------------------------
-        results = self.devs.filter(filter_func=reachable_devs).run(task=initialize_devices, bfs=self.bf)
+        results = self.devs.filter(filter_func=reachable_devs).run(
+            task=initialize_devices, bfs=self.bf
+        )
 
         for dev_name, items in results.items():
             if items[0].failed:


### PR DESCRIPTION
Currently, if a device is unreachable, the device is still initialized, resulting in a Batfish error, such as: Unable to find Batfish data. This is due to the device config not being pulled and the device not being imported.
The goal of this PR is to improve logging clarity when devices are unreachable, in turn making log parsing and troubleshooting easier in the event of device import issues.