### PR TITLE
Improve cable validation for duplicate interface connections

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -13,6 +13,7 @@ limitations under the License.
 """
 # pylint: disable=R1724,W0611,R1710,R1710,E1101,W0613,C0103,C0413,R0904
 
+from collections import defaultdict
 import logging
 import sys
 import os
@@ -665,21 +666,14 @@ class NetworkImporter:
         """
         Return the number of connections for each of the interfaces.
         """
-        a_z_device_interfaces = {"a": dict(), "z": dict()}
+        a_device_interfaces = defaultdict(int)
+        z_device_interfaces = defaultdict(int)
 
         for interface in self.cables.values():
-            a_z_device_interfaces["a"].setdefault(
-                tuple(interface.get_device_intf("a")), list()
-            ).append(1)
-            a_z_device_interfaces["z"].setdefault(
-                tuple(interface.get_device_intf("z")), list()
-            ).append(1)
+            a_device_interfaces[interface.get_device_intf("a")] += 1
+            z_device_interfaces[interface.get_device_intf("z")] += 1
 
-        for side, device_interfaces in a_z_device_interfaces.items():
-            for device_interface, total in device_interfaces.items():
-                a_z_device_interfaces[side][device_interface] = sum(total)
-
-        return a_z_device_interfaces
+        return dict(a=a_device_interfaces, z=z_device_interfaces)
 
     def import_cabling(self):
 


### PR DESCRIPTION
This PR improves the cable validation for interfaces that have not yet been created yet and from CDP/LLDP are showing as the neighbor interface across multiple devices. In turn, preventing the cable from being created within Netbox.
The result is the initial cable/connection is created within Netbox. However, when Network-Importer comes to the 2nd instance of the interface, the remote update fails due to the interface already having a cable mapping. Shown below:
```
pynetbox.core.query.RequestError: The request failed with code 400 Bad Request: {'non_field_errors': ['The fields termination_b_type, termination_b_id must make a unique set.']}
```
