### PR TITLE
Update Configs Error Messaging

### DIFF
--- a/network_importer/drivers/cisco_default.py
+++ b/network_importer/drivers/cisco_default.py
@@ -55,14 +55,14 @@ class NetworkImporterDriver(DefaultNetworkImporterDriver):
         except NornirSubTaskError as exc:
             if isinstance(exc.result.exception, NetmikoAuthenticationException):
                 LOGGER.warning("Unable get the configuration because it can't connect to %s", task.host.name)
-                return Result(host=task.host, failed=True)
+                return Result(host=task.host, failed=True, exception=exc.result.exception)
 
             if isinstance(exc.result.exception, NetmikoTimeoutException):
                 LOGGER.warning("Unable get the configuration because the connection to %s timeout", task.host.name)
-                return Result(host=task.host, failed=True)
+                return Result(host=task.host, failed=True, exception=exc.result.exception)
 
-            LOGGER.debug("An exception occured while pulling the configuration", exc_info=True)
-            return Result(host=task.host, failed=True)
+            LOGGER.debug("An exception occurred while pulling the configuration", exc_info=True)
+            return Result(host=task.host, failed=True, exception=exc.result.exception)
 
         if result[0].failed:
             return result

--- a/network_importer/processors/get_config.py
+++ b/network_importer/processors/get_config.py
@@ -107,7 +107,10 @@ class GetConfig(BaseProcessor):
             return
 
         if result[0].failed:
-            LOGGER.warning("%s | Something went wrong while trying to update the configuration ", task.host.name)
+            if result[0].exception:
+                LOGGER.warning("%s | %s", task.host.name, result[0].exception)
+            else:
+                LOGGER.warning("%s | Something went wrong while trying to update the configuration ", task.host.name)
             host.data["status"] = "fail-other"
             return
 


### PR DESCRIPTION
Improved error messaging when updating configurations for Cisco devices.

Added exceptions to nornir result object.
`return Result(host=task.host, failed=True, exception=exc.result.exception)`

```
root@62f2b25c20a0:/local# network-importer --check --update-configs
2020-11-17 11:48:48,825 - network-importer - INFO - Updating configuration from devices .. 
2020-11-17 11:48:48,860 - network-importer - WARNING - [DEVICE NAME] | Something went wrong while trying to update the configuration 
2020-11-17 11:48:51,802 - network-importer - WARNING - [DEVICE NAME] | Authentication failed.
2020-11-17 11:48:52,490 - network-importer - WARNING - [DEVICE NAME] | Authentication failed.
2020-11-17 11:48:52,493 - network-importer - INFO - Import SOT Model
2020-11-17 11:48:55,073 - network-importer - INFO - Import Network Model
```

