### PR TITLE
Batfish error catching for missing configuration files.

### DIFF
--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -25,6 +25,7 @@ from pybatfish.exception import BatfishException
 import network_importer.config as config
 from network_importer.adapters.base import BaseAdapter
 
+from network_importer.exceptions import AdapterLoadFatalError
 from network_importer.inventory import reachable_devs, valid_and_reachable_devs
 from network_importer.tasks import check_if_reachable, warning_not_reachable
 from network_importer.drivers import dispatcher
@@ -108,7 +109,7 @@ class NetworkImporterAdapter(BaseAdapter):
         except BatfishException as exc:
             error = json.loads(str(exc).splitlines()[-1])
             error = re.sub(r"[^:]*:.", "", error["answerElements"][0]["answer"][0])
-            raise BatfishObjectNotValid("Snapshot", error)
+            raise AdapterLoadFatalError(error)
 
     def load_batfish(self):
         """Load all devices, interfaces and IP Addresses from Batfish."""

--- a/network_importer/adapters/network_importer/exceptions.py
+++ b/network_importer/adapters/network_importer/exceptions.py
@@ -16,13 +16,3 @@ limitations under the License.
 
 class BatfishObjectNotValid(Exception):
     """Exception to indicate that a given batfish object is not valid."""
-
-    def __init__(self, reason, message, **kwargs):
-        """Initialize exception class."""
-        super(BatfishObjectNotValid, self).__init__(kwargs)
-        self.reason = reason
-        self.message = message
-
-    def __str__(self):
-        """Modified string output."""
-        return f"{self.__class__.__name__}: {self.reason} - {self.message}"

--- a/network_importer/cli.py
+++ b/network_importer/cli.py
@@ -102,8 +102,9 @@ def main(config_file, limit, diff, apply, check, debug, update_configs):
 
     ni.init(limit=limit)
 
-    # # ------------------------------------------------------------------------------------
-    # # Update Remote if apply is enabled
+    # ------------------------------------------------------------------------------------
+    # Update Remote if apply is enabled
+    # ------------------------------------------------------------------------------------
     if apply:
         ni.sync()
 

--- a/network_importer/exceptions.py
+++ b/network_importer/exceptions.py
@@ -14,15 +14,5 @@ limitations under the License.
 """
 
 
-class NetworkImporterException(Exception):
+class AdapterLoadFatalError(Exception):
     """Network Importer Exception."""
-
-    def __init__(self, reason, message, **kwargs):
-        """Initialize exception class."""
-        super(NetworkImporterException, self).__init__(kwargs)
-        self.reason = reason
-        self.message = message
-
-    def __str__(self):
-        """Modified string output."""
-        return f"{self.__class__.__name__}: {self.reason} - {self.message}"


### PR DESCRIPTION
Not sure if this is the best method. 

The only way I could find to get the error back was through the string BatfishException produces. 
At the end of the string there is a dictionary with the error message in. The exception parses this string and takes out the dictionary using json.loads, then raise an exception using the new string.

``` python
        except BatfishException as exc:
            error = json.loads(str(exc).splitlines()[-1])
            raise Exception(error['answerElements'][0]['answer'][0])
```