### PR TITLE
Add python 3.8 in the testing matrix and update the dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ services:
 python:
   - 3.7
   - 3.8
-  - 3.9
 
 before_script:
   - "pip install invoke toml poetry ansible pynetbox"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ services:
   - "docker"
 python:
   - 3.7
+  - 3.8
+  - 3.9
 
 before_script:
   - "pip install invoke toml poetry ansible pynetbox"

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,18 +1,18 @@
 [[package]]
 name = "aiohttp"
-version = "3.7.2"
+version = "3.7.3"
 description = "Async http client/server framework (asyncio)"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-async-timeout = ">=3.0,<4.0"
-attrs = ">=17.3.0"
-chardet = ">=2.0,<4.0"
-multidict = ">=4.5,<7.0"
 typing-extensions = ">=3.6.5"
 yarl = ">=1.0,<2.0"
+async-timeout = ">=3.0,<4.0"
+chardet = ">=2.0,<4.0"
+attrs = ">=17.3.0"
+multidict = ">=4.5,<7.0"
 
 [package.extras]
 speedups = ["aiodns", "brotlipy", "cchardet"]
@@ -35,8 +35,8 @@ python-versions = ">=3.5"
 
 [package.dependencies]
 lazy-object-proxy = ">=1.4.0,<1.5.0"
-six = ">=1.12,<2.0"
 typed-ast = {version = ">=1.4.0,<1.5", markers = "implementation_name == \"cpython\" and python_version < \"3.8\""}
+six = ">=1.12,<2.0"
 wrapt = ">=1.11,<2.0"
 
 [[package]]
@@ -57,17 +57,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "attrs"
-version = "20.2.0"
+version = "20.3.0"
 description = "Classes Without Boilerplate"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "sphinx", "sphinx-rtd-theme", "pre-commit"]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+docs = ["furo", "sphinx", "zope.interface"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "six", "zope.interface", "furo", "sphinx", "pre-commit"]
 
 [[package]]
 name = "bandit"
@@ -78,11 +78,11 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
-GitPython = ">=1.0.1"
+stevedore = ">=1.20.0"
 PyYAML = ">=3.13"
 six = ">=1.10.0"
-stevedore = ">=1.20.0"
+colorama = {version = ">=0.3.9", markers = "platform_system == \"Windows\""}
+GitPython = ">=1.0.1"
 
 [[package]]
 name = "bcrypt"
@@ -93,12 +93,12 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-cffi = ">=1.1"
 six = ">=1.4.1"
+cffi = ">=1.1"
 
 [package.extras]
-tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "bidict"
@@ -109,11 +109,11 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
+test = ["hypothesis (<6)", "py (<2)", "pytest (<7)", "pytest-benchmark (>=3.2.0,<4)", "sortedcollections (<2)", "sortedcontainers (<3)", "Sphinx (<4)", "sphinx-autodoc-typehints (<2)"]
+docs = ["Sphinx (<4)", "sphinx-autodoc-typehints (<2)"]
 coverage = ["coverage (<6)", "pytest-cov (<3)"]
 dev = ["setuptools-scm", "hypothesis (<6)", "py (<2)", "pytest (<7)", "pytest-benchmark (>=3.2.0,<4)", "sortedcollections (<2)", "sortedcontainers (<3)", "Sphinx (<4)", "sphinx-autodoc-typehints (<2)", "coverage (<6)", "pytest-cov (<3)", "pre-commit (<3)", "tox (<4)"]
-docs = ["Sphinx (<4)", "sphinx-autodoc-typehints (<2)"]
 precommit = ["pre-commit (<3)"]
-test = ["hypothesis (<6)", "py (<2)", "pytest (<7)", "pytest-benchmark (>=3.2.0,<4)", "sortedcollections (<2)", "sortedcontainers (<3)", "Sphinx (<4)", "sphinx-autodoc-typehints (<2)"]
 
 [[package]]
 name = "black"
@@ -124,20 +124,20 @@ optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-appdirs = "*"
-attrs = ">=18.1.0"
-click = ">=6.5"
-pathspec = ">=0.6,<1"
 regex = "*"
-toml = ">=0.9.4"
 typed-ast = ">=1.4.0"
+toml = ">=0.9.4"
+attrs = ">=18.1.0"
+pathspec = ">=0.6,<1"
+click = ">=6.5"
+appdirs = "*"
 
 [package.extras]
 d = ["aiohttp (>=3.3.2)", "aiohttp-cors"]
 
 [[package]]
 name = "certifi"
-version = "2020.6.20"
+version = "2020.11.8"
 description = "Python package for providing Mozilla's CA Bundle."
 category = "main"
 optional = false
@@ -145,7 +145,7 @@ python-versions = "*"
 
 [[package]]
 name = "cffi"
-version = "1.14.3"
+version = "1.14.4"
 description = "Foreign Function Interface for Python calling C code."
 category = "main"
 optional = false
@@ -164,15 +164,15 @@ python-versions = "*"
 
 [[package]]
 name = "ciscoconfparse"
-version = "1.5.19"
+version = "1.5.20"
 description = "Parse, Audit, Query, Build, and Modify Cisco IOS-style configurations"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-colorama = "*"
 dnspython = "*"
+colorama = "*"
 passlib = "*"
 
 [[package]]
@@ -215,22 +215,22 @@ yaml = ["pyyaml"]
 
 [[package]]
 name = "cryptography"
-version = "3.2"
+version = "3.2.1"
 description = "cryptography is a package which provides cryptographic recipes and primitives to Python developers."
 category = "main"
 optional = false
 python-versions = ">=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*"
 
 [package.dependencies]
-cffi = ">=1.8,<1.11.3 || >1.11.3"
 six = ">=1.4.1"
+cffi = ">=1.8,<1.11.3 || >1.11.3"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
-pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
-ssh = ["bcrypt (>=3.1.5)"]
 test = ["pytest (>=3.6.0,!=3.9.0,!=3.9.1,!=3.9.2)", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+docstest = ["doc8", "pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+ssh = ["bcrypt (>=3.1.5)"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 
 [[package]]
 name = "deepdiff"
@@ -270,12 +270,12 @@ python-versions = ">=3.7,<4.0"
 
 [package.dependencies]
 colorama = ">=0.4.3,<0.5.0"
-pydantic = ">=1.6.1,<2.0.0"
 structlog = ">=20.1.0,<21.0.0"
+pydantic = ">=1.6.1,<2.0.0"
 
 [[package]]
 name = "dill"
-version = "0.3.2"
+version = "0.3.3"
 description = "serialize all of python"
 category = "main"
 optional = false
@@ -301,11 +301,11 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dnssec = ["cryptography (>=2.6)"]
 doh = ["requests", "requests-toolbelt"]
-idna = ["idna (>=2.1)"]
 curio = ["curio (>=1.2)", "sniffio (>=1.1)"]
+idna = ["idna (>=2.1)"]
 trio = ["trio (>=0.14.0)", "sniffio (>=1.1)"]
+dnssec = ["cryptography (>=2.6)"]
 
 [[package]]
 name = "fancycompleter"
@@ -316,8 +316,8 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-pyreadline = {version = "*", markers = "platform_system == \"Windows\""}
 pyrepl = ">=0.8.2"
+pyreadline = {version = "*", markers = "platform_system == \"Windows\""}
 
 [[package]]
 name = "flake8"
@@ -343,34 +343,34 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "genie"
-version = "20.9"
+version = "20.10"
 description = "Genie: THE standard pyATS Library System"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-dill = "*"
-"genie.libs.clean" = ">=20.9.0,<20.10.0"
-"genie.libs.conf" = ">=20.9.0,<20.10.0"
-"genie.libs.filetransferutils" = ">=20.9.0,<20.10.0"
-"genie.libs.health" = ">=20.9.0,<20.10.0"
-"genie.libs.ops" = ">=20.9.0,<20.10.0"
-"genie.libs.parser" = ">=20.9.0,<20.10.0"
-"genie.libs.sdk" = ">=20.9.0,<20.10.0"
-jsonpickle = "*"
-netaddr = "*"
-PrettyTable = "*"
 tqdm = "*"
+"genie.libs.conf" = ">=20.10.0,<20.11.0"
+"genie.libs.ops" = ">=20.10.0,<20.11.0"
+dill = "*"
+netaddr = "*"
+jsonpickle = "*"
+"genie.libs.filetransferutils" = ">=20.10.0,<20.11.0"
+"genie.libs.clean" = ">=20.10.0,<20.11.0"
+"genie.libs.parser" = ">=20.10.0,<20.11.0"
+PrettyTable = "*"
+"genie.libs.sdk" = ">=20.10.0,<20.11.0"
+"genie.libs.health" = ">=20.10.0,<20.11.0"
 
 [package.extras]
+full = ["genie.libs.conf", "genie.libs.clean", "genie.libs.health", "genie.libs.filetransferutils", "genie.libs.ops", "genie.libs.parser", "genie.libs.sdk", "pyats.robot (>=20.10.0,<20.11.0)", "genie.libs.robot (>=20.10.0,<20.11.0)", "genie.telemetry (>=20.10.0,<20.11.0)", "genie.trafficgen (>=20.10.0,<20.11.0)"]
+robot = ["pyats.robot (>=20.10.0,<20.11.0)", "genie.libs.robot (>=20.10.0,<20.11.0)"]
 dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme"]
-full = ["genie.libs.conf", "genie.libs.clean", "genie.libs.health", "genie.libs.filetransferutils", "genie.libs.ops", "genie.libs.parser", "genie.libs.sdk", "pyats.robot (>=20.9.0,<20.10.0)", "genie.libs.robot (>=20.9.0,<20.10.0)", "genie.telemetry (>=20.9.0,<20.10.0)", "genie.trafficgen (>=20.9.0,<20.10.0)"]
-robot = ["pyats.robot (>=20.9.0,<20.10.0)", "genie.libs.robot (>=20.9.0,<20.10.0)"]
 
 [[package]]
 name = "genie.libs.clean"
-version = "20.9.1"
+version = "20.10.1"
 description = "Genie Library for device clean support"
 category = "main"
 optional = false
@@ -385,7 +385,7 @@ dev = ["coverage", "paramiko", "restview", "sphinx", "sphinx-rtd-theme", "sphinx
 
 [[package]]
 name = "genie.libs.conf"
-version = "20.9"
+version = "20.10"
 description = "Genie libs Conf: Libraries to configures topology through Python object attributes"
 category = "main"
 optional = false
@@ -396,7 +396,7 @@ dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "genie.libs.filetransferutils"
-version = "20.9"
+version = "20.10"
 description = "Genie libs FileTransferUtils: Genie FileTransferUtils Libraries"
 category = "main"
 optional = false
@@ -410,7 +410,7 @@ dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "genie.libs.health"
-version = "20.9"
+version = "20.10.1"
 description = "pyATS Health Check for monitoring device health status"
 category = "main"
 optional = false
@@ -424,7 +424,7 @@ dev = ["coverage", "paramiko", "restview", "sphinx", "sphinx-rtd-theme", "sphinx
 
 [[package]]
 name = "genie.libs.ops"
-version = "20.9"
+version = "20.10"
 description = "Genie libs Ops: Libraries to retrieve operational state of the topology"
 category = "main"
 optional = false
@@ -435,7 +435,7 @@ dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "genie.libs.parser"
-version = "20.9"
+version = "20.10"
 description = "Genie libs Parser: Genie Parser Libraries"
 category = "main"
 optional = false
@@ -449,7 +449,7 @@ dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "genie.libs.sdk"
-version = "20.9.1"
+version = "20.10"
 description = "Genie libs sdk: Libraries containing all Triggers and Verifications"
 category = "main"
 optional = false
@@ -460,21 +460,6 @@ python-versions = "*"
 
 [package.extras]
 dev = ["coverage", "restview", "sphinx", "sphinxcontrib-napoleon", "sphinx-rtd-theme", "xmltodict"]
-
-[[package]]
-name = "genie.metaparser"
-version = "19.12"
-description = "Genie Library for automation Parser support"
-category = "main"
-optional = false
-python-versions = ">=3.4"
-
-[package.dependencies]
-"genie.libs.parser" = "*"
-pyats = "*"
-
-[package.extras]
-dev = ["coverage", "restview", "sphinx", "sphinx-rtd-theme", "sphinxcontrib-mockautodoc"]
 
 [[package]]
 name = "gitdb"
@@ -508,18 +493,18 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "importlib-metadata"
-version = "2.0.0"
+version = "3.1.1"
 description = "Read metadata from Python packages"
 category = "main"
 optional = false
-python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*,>=2.7"
+python-versions = ">=3.6"
 
 [package.dependencies]
 zipp = ">=0.5"
 
 [package.extras]
-docs = ["sphinx", "rst.linker"]
-testing = ["packaging", "pep517", "importlib-resources (>=1.3)"]
+docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-cov", "jaraco.test (>=3.2.0)", "packaging", "pep517", "pyfakefs", "flufl.flake8", "pytest-black (>=0.3.7)", "pytest-mypy", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "invoke"
@@ -546,9 +531,9 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
 pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
 requirements_deprecated_finder = ["pipreqs", "pip-api"]
-colors = ["colorama (>=0.4.3,<0.5.0)"]
 
 [[package]]
 name = "jinja2"
@@ -566,37 +551,19 @@ i18n = ["Babel (>=0.8)"]
 
 [[package]]
 name = "jsonpickle"
-version = "1.4.1"
+version = "1.4.2"
 description = "Python library for serializing any arbitrary object graph into JSON"
 category = "main"
 optional = false
 python-versions = ">=2.7"
 
 [package.dependencies]
-importlib-metadata = "*"
+importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sqlalchemy", "enum34", "jsonlib"]
 "testing.libs" = ["demjson", "simplejson", "ujson", "yajl"]
-
-[[package]]
-name = "jsonschema"
-version = "3.2.0"
-description = "An implementation of JSON Schema validation for Python"
-category = "main"
-optional = false
-python-versions = "*"
-
-[package.dependencies]
-attrs = ">=17.4.0"
-importlib-metadata = {version = "*", markers = "python_version < \"3.8\""}
-pyrsistent = ">=0.14.0"
-six = ">=1.11.0"
-
-[package.extras]
-format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
-format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
+testing = ["coverage (<5)", "pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "sqlalchemy", "enum34", "jsonlib"]
 
 [[package]]
 name = "junit-xml"
@@ -611,26 +578,25 @@ six = "*"
 
 [[package]]
 name = "junos-eznc"
-version = "2.5.3"
+version = "2.5.4"
 description = "Junos 'EZ' automation for non-programmers"
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
-jinja2 = ">=2.7.1"
-lxml = ">=3.2.4"
-ncclient = ">=0.6.3"
-netaddr = "*"
-ntc-templates = "*"
-paramiko = ">=1.15.2"
-pyparsing = "*"
-pyserial = "*"
 PyYAML = ">=5.1"
+lxml = ">=3.2.4"
+netaddr = "*"
+ncclient = ">=0.6.3"
 scp = ">=0.7.0"
 six = "*"
-transitions = "*"
+jinja2 = ">=2.7.1"
 yamlordereddictloader = "*"
+pyparsing = "*"
+transitions = "*"
+pyserial = "*"
+paramiko = ">=1.15.2"
 
 [[package]]
 name = "lazy-object-proxy"
@@ -642,17 +608,17 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "lxml"
-version = "4.6.1"
+version = "4.6.2"
 description = "Powerful and Pythonic XML processing library combining libxml2/libxslt with the ElementTree API."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, != 3.4.*"
 
 [package.extras]
+source = ["Cython (>=0.29.7)"]
 cssselect = ["cssselect (>=0.7)"]
 html5 = ["html5lib"]
 htmlsoup = ["beautifulsoup4"]
-source = ["Cython (>=0.29.7)"]
 
 [[package]]
 name = "markupsafe"
@@ -672,7 +638,7 @@ python-versions = "*"
 
 [[package]]
 name = "more-itertools"
-version = "8.5.0"
+version = "8.6.0"
 description = "More routines for operating on iterables, beyond itertools"
 category = "dev"
 optional = false
@@ -680,11 +646,11 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "multidict"
-version = "5.0.0"
+version = "5.1.0"
 description = "multidict implementation"
 category = "main"
 optional = false
-python-versions = ">=3.5"
+python-versions = ">=3.6"
 
 [[package]]
 name = "mypy-extensions"
@@ -703,20 +669,20 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-cffi = ">=1.11.3"
 ciscoconfparse = "*"
+lxml = ">=4.3.0"
+netmiko = ">=3.1.0"
+pyeapi = ">=0.8.2"
+netaddr = "*"
+cffi = ">=1.11.3"
+pyYAML = "*"
+textfsm = "*"
 future = "*"
 jinja2 = "*"
-junos-eznc = ">=2.2.1"
-lxml = ">=4.3.0"
-netaddr = "*"
-netmiko = ">=3.1.0"
-paramiko = ">=2.6.0"
-pyeapi = ">=0.8.2"
-pyYAML = "*"
 requests = ">=2.7.0"
+junos-eznc = ">=2.2.1"
 scp = "*"
-textfsm = "*"
+paramiko = ">=2.6.0"
 
 [[package]]
 name = "ncclient"
@@ -728,8 +694,8 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
 lxml = ">=3.3.0"
-paramiko = ">=1.15.0"
 six = "*"
+paramiko = ">=1.15.0"
 
 [[package]]
 name = "netaddr"
@@ -741,22 +707,22 @@ python-versions = "*"
 
 [[package]]
 name = "netconan"
-version = "0.11.2"
+version = "0.11.3"
 description = "Netconan network configuration anonymization utilities"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
+six = "<2.0.0"
+passlib = "<2.0.0"
+ipaddress = "<2.0.0"
 bidict = "<1.0.0"
 configargparse = "<1.0.0"
-ipaddress = "<2.0.0"
-passlib = "<2.0.0"
-six = "<2.0.0"
 
 [package.extras]
-dev = ["flake8 (<4.0.0)", "flake8-docstrings (<2.0.0)", "pydocstyle (<4.0.0)"]
 test = ["pytest (>=4.6.0,<5.0.0)", "pytest-cov (<3.0.0)", "requests-mock (<2.0.0)", "testfixtures (<7.0.0)", "zipp (<2.2)"]
+dev = ["flake8 (<4.0.0)", "flake8-docstrings (<2.0.0)", "pydocstyle (<4.0.0)"]
 
 [[package]]
 name = "netmiko"
@@ -768,10 +734,10 @@ python-versions = "*"
 
 [package.dependencies]
 ntc-templates = "*"
-paramiko = ">=2.6.0"
-pyserial = "*"
-scp = ">=0.13.2"
 tenacity = "*"
+pyserial = "*"
+paramiko = ">=2.6.0"
+scp = ">=0.13.2"
 
 [package.extras]
 test = ["pyyaml (>=5.1.2)", "pytest (>=5.1.2)"]
@@ -785,16 +751,16 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
-colorama = ">=0.4.1,<0.5.0"
-jinja2 = ">=2,<3"
-mypy_extensions = ">=0.4.1,<0.5.0"
 napalm = ">=2.5.0"
-ncclient = ">=0.6.6,<0.7.0"
 netmiko = ">=2.4.2"
-paramiko = ">=2.7,<3.0"
-requests = ">=2,<3"
 "ruamel.yaml" = ">=0.16,<0.17"
 typing_extensions = ">=3.7,<4.0"
+ncclient = ">=0.6.6,<0.7.0"
+jinja2 = ">=2,<3"
+colorama = ">=0.4.1,<0.5.0"
+requests = ">=2,<3"
+mypy_extensions = ">=0.4.1,<0.5.0"
+paramiko = ">=2.7,<3.0"
 
 [package.extras]
 docs = ["sphinx (>=1,<2)", "sphinx_rtd_theme (>=0.4,<0.5)", "sphinxcontrib-napoleon (>=0.7,<0.8)", "jupyter (>=1,<2)", "nbsphinx (>=0.5,<0.6)", "pygments (>=2,<3)", "sphinx-issues (>=1.2,<2.0)"]
@@ -815,7 +781,7 @@ dev = ["pytest", "pyyaml", "black", "yamllint", "ruamel.yaml"]
 
 [[package]]
 name = "numpy"
-version = "1.19.2"
+version = "1.19.4"
 description = "NumPy is the fundamental package for array computing with Python."
 category = "main"
 optional = false
@@ -831,7 +797,7 @@ python-versions = ">=3.5"
 
 [[package]]
 name = "packaging"
-version = "20.4"
+version = "20.7"
 description = "Core utilities for Python packages"
 category = "dev"
 optional = false
@@ -839,7 +805,6 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
 pyparsing = ">=2.0.2"
-six = "*"
 
 [[package]]
 name = "pandas"
@@ -850,9 +815,9 @@ optional = false
 python-versions = ">=3.5.3"
 
 [package.dependencies]
-numpy = ">=1.13.3"
 python-dateutil = ">=2.6.1"
 pytz = ">=2017.2"
+numpy = ">=1.13.3"
 
 [package.extras]
 test = ["pytest (>=4.0.2)", "pytest-xdist", "hypothesis (>=3.58)"]
@@ -866,13 +831,13 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
+pynacl = ">=1.0.1"
 bcrypt = ">=3.1.3"
 cryptography = ">=2.5"
-pynacl = ">=1.0.1"
 
 [package.extras]
-all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
+all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 gssapi = ["pyasn1 (>=0.1.7)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 invoke = ["invoke (>=1.3)"]
 
@@ -887,12 +852,12 @@ python-versions = "*"
 [package.extras]
 argon2 = ["argon2-cffi (>=18.2.0)"]
 bcrypt = ["bcrypt (>=3.1.0)"]
-build_docs = ["sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)", "cloud-sptheme (>=1.10.1)"]
 totp = ["cryptography"]
+build_docs = ["sphinx (>=1.6)", "sphinxcontrib-fulltoc (>=1.2.0)", "cloud-sptheme (>=1.10.1)"]
 
 [[package]]
 name = "pathspec"
-version = "0.8.0"
+version = "0.8.1"
 description = "Utility library for gitignore style pattern matching of file paths."
 category = "main"
 optional = false
@@ -920,8 +885,8 @@ pygments = "*"
 wmctrl = "*"
 
 [package.extras]
-funcsigs = ["funcsigs"]
 testing = ["funcsigs", "pytest"]
+funcsigs = ["funcsigs"]
 
 [[package]]
 name = "pluggy"
@@ -947,11 +912,11 @@ python-versions = "*"
 
 [[package]]
 name = "prettytable"
-version = "1.0.1"
+version = "2.0.0"
 description = "A simple Python library for easily displaying tabular data in a visually appealing ASCII table format"
 category = "main"
 optional = false
-python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
+python-versions = ">=3.6"
 
 [package.dependencies]
 wcwidth = "*"
@@ -988,104 +953,104 @@ python-versions = "*"
 
 [[package]]
 name = "pyats"
-version = "20.9"
+version = "20.10"
 description = "pyATS - Python Automation Test System"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.aereport" = ">=20.9.0,<20.10.0"
-"pyats.aetest" = ">=20.9.0,<20.10.0"
-"pyats.async" = ">=20.9.0,<20.10.0"
-"pyats.connections" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.easypy" = ">=20.9.0,<20.10.0"
-"pyats.kleenex" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.reporter" = ">=20.9.0,<20.10.0"
-"pyats.results" = ">=20.9.0,<20.10.0"
-"pyats.tcl" = ">=20.9.0,<20.10.0"
-"pyats.topology" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+"pyats.log" = ">=20.10.0,<20.11.0"
+"pyats.topology" = ">=20.10.0,<20.11.0"
+"pyats.easypy" = ">=20.10.0,<20.11.0"
+"pyats.kleenex" = ">=20.10.0,<20.11.0"
+"pyats.connections" = ">=20.10.0,<20.11.0"
+"pyats.reporter" = ">=20.10.0,<20.11.0"
+"pyats.aetest" = ">=20.10.0,<20.11.0"
+"pyats.tcl" = ">=20.10.0,<20.11.0"
+"pyats.async" = ">=20.10.0,<20.11.0"
+"pyats.utils" = ">=20.10.0,<20.11.0"
+"pyats.aereport" = ">=20.10.0,<20.11.0"
+"pyats.results" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
-full = ["cookiecutter", "genie (>=20.9.0,<20.10.0)", "pyats.robot (>=20.9.0,<20.10.0)", "genie.libs.robot (>=20.9.0,<20.10.0)", "genie.telemetry (>=20.9.0,<20.10.0)", "genie.trafficgen (>=20.9.0,<20.10.0)", "pyats.contrib (>=20.9.0,<20.10.0)"]
-library = ["genie (>=20.9.0,<20.10.0)"]
-robot = ["pyats.robot (>=20.9.0,<20.10.0)", "genie.libs.robot (>=20.9.0,<20.10.0)"]
+full = ["cookiecutter", "genie (>=20.10.0,<20.11.0)", "pyats.robot (>=20.10.0,<20.11.0)", "genie.libs.robot (>=20.10.0,<20.11.0)", "genie.telemetry (>=20.10.0,<20.11.0)", "genie.trafficgen (>=20.10.0,<20.11.0)", "pyats.contrib (>=20.10.0,<20.11.0)"]
+robot = ["pyats.robot (>=20.10.0,<20.11.0)", "genie.libs.robot (>=20.10.0,<20.11.0)"]
+library = ["genie (>=20.10.0,<20.11.0)"]
 template = ["cookiecutter"]
 
 [[package]]
 name = "pyats.aereport"
-version = "20.9"
+version = "20.10"
 description = "pyATS AEreport: Result Collection and Reporting"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
+"pyats.log" = ">=20.10.0,<20.11.0"
+psutil = "*"
+"pyats.results" = ">=20.10.0,<20.11.0"
 jinja2 = "*"
 junit-xml = "*"
-psutil = "*"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.results" = ">=20.9.0,<20.10.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.aetest"
-version = "20.9.2"
+version = "20.10"
 description = "pyATS AEtest: Testscript Engine"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-jinja2 = ">=2.9"
-"pyats.aereport" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.results" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+"pyats.log" = ">=20.10.0,<20.11.0"
 pyyaml = "*"
+jinja2 = ">=2.9"
+"pyats.utils" = ">=20.10.0,<20.11.0"
+"pyats.aereport" = ">=20.10.0,<20.11.0"
+"pyats.results" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.async"
-version = "20.9"
+version = "20.10"
 description = "pyATS Async: Asynchronous Execution of Codes"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.log" = ">=20.9.0,<20.10.0"
+"pyats.log" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.connections"
-version = "20.9"
+version = "20.10"
 description = "pyATS Connection: Device Connection Handling & Base Classes"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.async" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-unicon = ">=20.9.0,<20.10.0"
+unicon = ">=20.10.0,<20.11.0"
+"pyats.async" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.datastructures"
-version = "20.9"
+version = "20.10"
 description = "pyATS Datastructures: Extended Datastructures for Grownups"
 category = "main"
 optional = false
@@ -1096,86 +1061,86 @@ dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.easypy"
-version = "20.9"
+version = "20.10"
 description = "pyATS Easypy: launcher and runtime environment"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-distro = "*"
-jinja2 = "*"
+"pyats.log" = ">=20.10.0,<20.11.0"
+"pyats.topology" = ">=20.10.0,<20.11.0"
+"pyats.kleenex" = ">=20.10.0,<20.11.0"
 psutil = "*"
-"pyats.aereport" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.kleenex" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.results" = ">=20.9.0,<20.10.0"
-"pyats.topology" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+jinja2 = "*"
+distro = "*"
+"pyats.utils" = ">=20.10.0,<20.11.0"
+"pyats.aereport" = ">=20.10.0,<20.11.0"
+"pyats.results" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.kleenex"
-version = "20.9.1"
+version = "20.10"
 description = "pyATS Kleenex: Testbed Preparation, Clean & Finalization"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
+"pyats.log" = ">=20.10.0,<20.11.0"
+"pyats.topology" = ">=20.10.0,<20.11.0"
+"pyats.async" = ">=20.10.0,<20.11.0"
 distro = "*"
-"pyats.aetest" = ">=20.9.0,<20.10.0"
-"pyats.async" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.topology" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+"pyats.utils" = ">=20.10.0,<20.11.0"
 requests = "*"
+"pyats.aetest" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.log"
-version = "20.9.1"
+version = "20.10"
 description = "pyATS Log: Logging Format and Utilities"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-aiohttp = "*"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-python-socketio = "*"
 pyyaml = "*"
+python-socketio = "*"
+aiohttp = "*"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.reporter"
-version = "20.9"
+version = "20.10"
 description = "pyATS Reporter: Result Collection and Reporting"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.aereport" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
-"pyats.results" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+"pyats.log" = ">=20.10.0,<20.11.0"
 pyyaml = "*"
+"pyats.aereport" = ">=20.10.0,<20.11.0"
+"pyats.results" = ">=20.10.0,<20.11.0"
+"pyats.utils" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.results"
-version = "20.9.1"
+version = "20.10"
 description = "pyATS Results: Representing Results using Objects"
 category = "main"
 optional = false
@@ -1186,49 +1151,49 @@ dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.tcl"
-version = "20.9"
+version = "20.10"
 description = "pyATS Tcl: Tcl Integration and Objects"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.log" = ">=20.9.0,<20.10.0"
+"pyats.log" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.topology"
-version = "20.9"
+version = "20.10"
 description = "pyATS Topology: Topology Objects and Testbed YAMLs"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-"pyats.connections" = ">=20.9.0,<20.10.0"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.utils" = ">=20.9.0,<20.10.0"
+"pyats.connections" = ">=20.10.0,<20.11.0"
 pyyaml = "*"
+"pyats.utils" = ">=20.10.0,<20.11.0"
 yamllint = "*"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
 
 [[package]]
 name = "pyats.utils"
-version = "20.9"
+version = "20.10"
 description = "pyATS Utils: Utilities Module"
 category = "main"
 optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
+"pyats.topology" = ">=20.10.0,<20.11.0"
+"pyats.datastructures" = ">=20.10.0,<20.11.0"
 distro = "*"
-"pyats.datastructures" = ">=20.9.0,<20.10.0"
-"pyats.topology" = ">=20.9.0,<20.10.0"
 
 [package.extras]
 dev = ["sphinx", "sphinx-rtd-theme"]
@@ -1242,16 +1207,16 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
+PyYAML = "*"
+simplejson = "*"
+netconan = ">=0.11.0"
+deprecated = "*"
 attrs = ">=18.1.0"
 deepdiff = "*"
-deprecated = "*"
-netconan = ">=0.11.0"
-pandas = ">=0.25.2,<1"
 python-dateutil = "*"
-PyYAML = "*"
 requests = "*"
+pandas = ">=0.25.2,<1"
 requests-toolbelt = "*"
-simplejson = "*"
 
 [package.extras]
 capirca = ["capirca", "absl-py (>=0.8.0)"]
@@ -1275,7 +1240,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pycryptodomex"
-version = "3.9.8"
+version = "3.9.9"
 description = "Cryptographic library for Python"
 category = "main"
 optional = false
@@ -1283,7 +1248,7 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [[package]]
 name = "pydantic"
-version = "1.7"
+version = "1.7.3"
 description = "Data validation and settings management using python 3.6 type hinting"
 category = "main"
 optional = false
@@ -1291,8 +1256,8 @@ python-versions = ">=3.6"
 
 [package.extras]
 dotenv = ["python-dotenv (>=0.10.4)"]
-email = ["email-validator (>=1.0.3)"]
 typing_extensions = ["typing-extensions (>=3.7.2)"]
+email = ["email-validator (>=1.0.3)"]
 
 [[package]]
 name = "pydocstyle"
@@ -1307,7 +1272,7 @@ snowballstemmer = "*"
 
 [[package]]
 name = "pyeapi"
-version = "0.8.3"
+version = "0.8.4"
 description = "Python Client for eAPI"
 category = "main"
 optional = false
@@ -1317,8 +1282,8 @@ python-versions = "*"
 netaddr = "*"
 
 [package.extras]
-dev = ["check-manifest", "pep8", "pyflakes", "twine"]
 test = ["coverage", "mock"]
+dev = ["check-manifest", "pep8", "pyflakes", "twine"]
 
 [[package]]
 name = "pyflakes"
@@ -1346,10 +1311,10 @@ python-versions = ">=3.5.*"
 
 [package.dependencies]
 astroid = ">=2.4.0,<=2.5"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-isort = ">=4.2.5,<6"
 mccabe = ">=0.6,<0.7"
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
 toml = ">=0.7.1"
+isort = ">=4.2.5,<6"
 
 [[package]]
 name = "pyment"
@@ -1368,8 +1333,8 @@ optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
 [package.dependencies]
-cffi = ">=1.4.1"
 six = "*"
+cffi = ">=1.4.1"
 
 [package.extras]
 docs = ["sphinx (>=1.6.5)", "sphinx-rtd-theme"]
@@ -1412,20 +1377,15 @@ optional = false
 python-versions = "*"
 
 [[package]]
-name = "pyrsistent"
-version = "0.17.3"
-description = "Persistent/Functional/Immutable data structures"
-category = "main"
-optional = false
-python-versions = ">=3.5"
-
-[[package]]
 name = "pyserial"
-version = "3.4"
+version = "3.5"
 description = "Python Serial Port Extension"
 category = "main"
 optional = false
 python-versions = "*"
+
+[package.extras]
+cp2110 = ["hidapi"]
 
 [[package]]
 name = "pysmi"
@@ -1447,9 +1407,9 @@ optional = false
 python-versions = "*"
 
 [package.dependencies]
-pyasn1 = ">=0.2.3"
 pycryptodomex = "*"
 pysmi = "*"
+pyasn1 = ">=0.2.3"
 
 [[package]]
 name = "pytest"
@@ -1460,15 +1420,15 @@ optional = false
 python-versions = ">=3.5"
 
 [package.dependencies]
-atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
-attrs = ">=17.4.0"
-colorama = {version = "*", markers = "sys_platform == \"win32\""}
-importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
 more-itertools = ">=4.0.0"
-packaging = "*"
-pluggy = ">=0.12,<1.0"
 py = ">=1.5.0"
 wcwidth = "*"
+packaging = "*"
+importlib-metadata = {version = ">=0.12", markers = "python_version < \"3.8\""}
+colorama = {version = "*", markers = "sys_platform == \"win32\""}
+attrs = ">=17.4.0"
+pluggy = ">=0.12,<1.0"
+atomicwrites = {version = ">=1.0", markers = "sys_platform == \"win32\""}
 
 [package.extras]
 checkqa-mypy = ["mypy (==v0.761)"]
@@ -1487,7 +1447,7 @@ six = ">=1.5"
 
 [[package]]
 name = "python-engineio"
-version = "3.13.2"
+version = "3.14.2"
 description = "Engine.IO server"
 category = "main"
 optional = false
@@ -1497,28 +1457,28 @@ python-versions = "*"
 six = ">=1.9.0"
 
 [package.extras]
-asyncio_client = ["aiohttp (>=3.4)"]
 client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
+asyncio_client = ["aiohttp (>=3.4)"]
 
 [[package]]
 name = "python-socketio"
-version = "4.6.0"
+version = "4.6.1"
 description = "Socket.IO server"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
-python-engineio = ">=3.13.0"
 six = ">=1.9.0"
+python-engineio = ">=3.13.0,<4"
 
 [package.extras]
-asyncio_client = ["aiohttp (>=3.4)", "websockets (>=7.0)"]
 client = ["requests (>=2.21.0)", "websocket-client (>=0.54.0)"]
+asyncio_client = ["aiohttp (>=3.4)", "websockets (>=7.0)"]
 
 [[package]]
 name = "pytz"
-version = "2020.1"
+version = "2020.4"
 description = "World timezone definitions, modern and historical"
 category = "main"
 optional = false
@@ -1534,7 +1494,7 @@ python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [[package]]
 name = "regex"
-version = "2020.10.23"
+version = "2020.11.13"
 description = "Alternative regular expression module, to replace re."
 category = "dev"
 optional = false
@@ -1542,17 +1502,17 @@ python-versions = "*"
 
 [[package]]
 name = "requests"
-version = "2.24.0"
+version = "2.25.0"
 description = "Python HTTP for Humans."
 category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
 [package.dependencies]
+idna = ">=2.5,<3"
 certifi = ">=2017.4.17"
 chardet = ">=3.0.2,<4"
-idna = ">=2.5,<3"
-urllib3 = ">=1.21.1,<1.25.0 || >1.25.0,<1.25.1 || >1.25.1,<1.26"
+urllib3 = ">=1.21.1,<1.27"
 
 [package.extras]
 security = ["pyOpenSSL (>=0.14)", "cryptography (>=1.3.4)"]
@@ -1571,8 +1531,8 @@ requests = ">=2.3,<3"
 six = "*"
 
 [package.extras]
-fixture = ["fixtures"]
 test = ["fixtures", "mock", "purl", "pytest", "sphinx", "testrepository (>=0.0.18)", "testtools"]
+fixture = ["fixtures"]
 
 [[package]]
 name = "requests-toolbelt"
@@ -1587,17 +1547,17 @@ requests = ">=2.0.1,<3.0.0"
 
 [[package]]
 name = "rich"
-version = "9.2.0"
+version = "9.3.0"
 description = "Render rich text, tables, progress bars, syntax highlighting, markdown and more to the terminal"
 category = "main"
 optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.dependencies]
+typing-extensions = ">=3.7.4,<4.0.0"
+pygments = ">=2.6.0,<3.0.0"
 colorama = ">=0.4.0,<0.5.0"
 commonmark = ">=0.9.0,<0.10.0"
-pygments = ">=2.6.0,<3.0.0"
-typing-extensions = ">=3.7.4,<4.0.0"
 
 [package.extras]
 jupyter = ["ipywidgets (>=7.5.1,<8.0.0)"]
@@ -1670,7 +1630,7 @@ python-versions = "*"
 
 [[package]]
 name = "stevedore"
-version = "3.2.2"
+version = "3.3.0"
 description = "Manage dynamic plugins for Python applications"
 category = "dev"
 optional = false
@@ -1692,10 +1652,10 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-azure-pipelines = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "pytest-azurepipelines", "python-rapidjson", "pytest-asyncio"]
-dev = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "sphinx", "twisted", "pre-commit", "python-rapidjson", "pytest-asyncio"]
 docs = ["sphinx", "twisted"]
 tests = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "python-rapidjson", "pytest-asyncio"]
+azure-pipelines = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "pytest-azurepipelines", "python-rapidjson", "pytest-asyncio"]
+dev = ["coverage", "freezegun (>=0.2.8)", "pretend", "pytest (>=3.3.0)", "simplejson", "sphinx", "twisted", "pre-commit", "python-rapidjson", "pytest-asyncio"]
 
 [[package]]
 name = "tenacity"
@@ -1733,26 +1693,26 @@ six = "*"
 
 [[package]]
 name = "toml"
-version = "0.10.1"
+version = "0.10.2"
 description = "Python Library for Tom's Obvious, Minimal Language"
 category = "main"
 optional = false
-python-versions = "*"
+python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "tqdm"
-version = "4.51.0"
+version = "4.54.0"
 description = "Fast, Extensible Progress Meter"
 category = "main"
 optional = false
-python-versions = ">=2.6, !=3.0.*, !=3.1.*"
+python-versions = "!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,>=2.7"
 
 [package.extras]
-dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown"]
+dev = ["py-make (>=0.1.0)", "twine", "argopt", "pydoc-markdown", "wheel"]
 
 [[package]]
 name = "transitions"
-version = "0.8.4"
+version = "0.8.5"
 description = "A lightweight, object-oriented Python state machine implementation with many extensions."
 category = "main"
 optional = false
@@ -1762,8 +1722,8 @@ python-versions = "*"
 six = "*"
 
 [package.extras]
-diagrams = ["pygraphviz"]
 test = ["pytest"]
+diagrams = ["pygraphviz"]
 
 [[package]]
 name = "typed-ast"
@@ -1783,7 +1743,7 @@ python-versions = "*"
 
 [[package]]
 name = "unicon"
-version = "20.9"
+version = "20.10"
 description = "Unicon Connection Library"
 category = "main"
 optional = false
@@ -1792,31 +1752,31 @@ python-versions = ">=3.5"
 [package.dependencies]
 dill = "*"
 pyyaml = "*"
-"unicon.plugins" = ">=20.9.0,<20.10.0"
+"unicon.plugins" = ">=20.10.0,<20.11.0"
 
 [package.extras]
-dev = ["cisco-distutils", "coverage", "restview", "sphinx", "sphinxcontrib-napoleon", "sphinxcontrib-mockautodoc", "sphinx-rtd-theme"]
 pyats = ["pyats"]
 robot = ["robotframework"]
+dev = ["cisco-distutils", "coverage", "restview", "sphinx", "sphinxcontrib-napoleon", "sphinxcontrib-mockautodoc", "sphinx-rtd-theme"]
 
 [[package]]
 name = "unicon.plugins"
-version = "20.9"
+version = "20.10"
 description = "Unicon Connection Library Plugins"
 category = "main"
 optional = false
 python-versions = "*"
 
 [package.dependencies]
+unicon = ">=20.10.0,<20.11.0"
 pyyaml = "*"
-unicon = ">=20.9.0,<20.10.0"
 
 [package.extras]
 dev = ["setuptools", "pip", "wheel", "coverage", "restview", "sphinx", "sphinxcontrib-napoleon", "sphinxcontrib-mockautodoc", "sphinx-rtd-theme"]
 
 [[package]]
 name = "urllib3"
-version = "1.25.11"
+version = "1.26.2"
 description = "HTTP library with thread-safe connection pooling, file post, and more."
 category = "main"
 optional = false
@@ -1884,16 +1844,16 @@ pyyaml = "*"
 
 [[package]]
 name = "yarl"
-version = "1.6.2"
+version = "1.6.3"
 description = "Yet another URL library"
 category = "main"
 optional = false
 python-versions = ">=3.6"
 
 [package.dependencies]
-idna = ">=2.0"
-multidict = ">=4.0"
 typing-extensions = {version = ">=3.7.4", markers = "python_version < \"3.8\""}
+multidict = ">=4.0"
+idna = ">=2.0"
 
 [[package]]
 name = "zipp"
@@ -1910,43 +1870,47 @@ testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-flake
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "059adf3f1d12bbb640335b8bbc26b63becbff932d187c1af6f5f0106b558592e"
+content-hash = "14b8825b71aac563ece4ef2b795f407582ecee2774a637b0791906bedb52447a"
 
 [metadata.files]
 aiohttp = [
-    {file = "aiohttp-3.7.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0989ff15834a4503056d103077ec3652f9ea5699835e1ceaee46b91cf59830bf"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:8fbeeb2296bb9fe16071a674eadade7391be785ae0049610e64b60ead6abcdd7"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:48104c883099c0e614c5c38f98c1d174a2c68f52f58b2a6e5a07b59df78262ab"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:c9a415f4f2764ab6c7d63ee6b86f02a46b4df9bc11b0de7ffef206908b7bf0b4"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:7e26712871ebaf55497a60f55483dc5e74326d1fb0bfceab86ebaeaa3a266733"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:8319a55de469d5af3517dfe1f6a77f248f6668c5a552396635ef900f058882ef"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2aea79734ac5ceeac1ec22b4af4efb4efd6a5ca3d73d77ec74ed782cf318f238"},
-    {file = "aiohttp-3.7.2-cp36-cp36m-win_amd64.whl", hash = "sha256:be9fa3fe94fc95e9bf84e84117a577c892906dd3cb0a95a7ae21e12a84777567"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f04dcbf6af1868048a9b4754b1684c669252aa2419aa67266efbcaaead42ced7"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2e886611b100c8c93b753b457e645c5e4b8008ec443434d2a480e5a2bb3e6514"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:cdbb65c361ff790c424365a83a496fc8dd1983689a5fb7c6852a9a3ff1710c61"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:8a8addd41320637c1445fea0bae1fd9fe4888acc2cd79217ee33e5d1c83cfe01"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:b822bf7b764283b5015e3c49b7bb93f37fc03545f4abe26383771c6b1c813436"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:ad5c3559e3cd64f746df43fa498038c91aa14f5d7615941ea5b106e435f3b892"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:835bd35e14e4f36414e47c195e6645449a0a1c3fd5eeae4b7f22cb4c5e4f503a"},
-    {file = "aiohttp-3.7.2-cp37-cp37m-win_amd64.whl", hash = "sha256:11e087c316e933f1f52f3d4a09ce13f15ad966fc43df47f44ca4e8067b6a2e0d"},
-    {file = "aiohttp-3.7.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f8c583c31c6e790dc003d9d574e3ed2c5b337947722965096c4d684e4f183570"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b84cef790cb93cec82a468b7d2447bf16e3056d2237b652e80f57d653b61da88"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:4afd8002d9238e5e93acf1a8baa38b3ddf1f7f0ebef174374131ff0c6c2d7973"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:a1f1cc11c9856bfa7f1ca55002c39070bde2a97ce48ef631468e99e2ac8e3fe6"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:7f1aeb72f14b9254296cdefa029c00d3c4550a26e1059084f2ee10d22086c2d0"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:67f8564c534d75c1d613186939cee45a124d7d37e7aece83b17d18af665b0d7a"},
-    {file = "aiohttp-3.7.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:184ead67248274f0e20b0cd6bb5f25209b2fad56e5373101cc0137c32c825c87"},
-    {file = "aiohttp-3.7.2-cp38-cp38-win_amd64.whl", hash = "sha256:6e0d1231a626d07b23f6fe904caa44efb249da4222d8a16ab039fb2348722292"},
-    {file = "aiohttp-3.7.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:476b1f8216e59a3c2ffb71b8d7e1da60304da19f6000d422bacc371abb0fc43d"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:89c1aa729953b5ac6ca3c82dcbd83e7cdecfa5cf9792c78c154a642e6e29303d"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c53f1d2bd48f5f407b534732f5b3c6b800a58e70b53808637848d8a9ee127fe7"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:06efdb01ab71ec20786b592d510d1d354fbe0b2e4449ee47067b9ca65d45a006"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:027be45c4b37e21be81d07ae5242361d73eebad1562c033f80032f955f34df82"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:1c36b7ef47cfbc150314c2204cd73613d96d6d0982d41c7679b7cdcf43c0e979"},
-    {file = "aiohttp-3.7.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:c588a0f824dc7158be9eec1ff465d1c868ad69a4dc518cd098cc11e4f7da09d9"},
-    {file = "aiohttp-3.7.2-cp39-cp39-win_amd64.whl", hash = "sha256:547b196a7177511da4f475fc81d0bb88a51a8d535c7444bbf2338b6dc82cb996"},
-    {file = "aiohttp-3.7.2.tar.gz", hash = "sha256:c6da1af59841e6d43255d386a2c4bfb59c0a3b262bdb24325cc969d211be6070"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:328b552513d4f95b0a2eea4c8573e112866107227661834652a8984766aa7656"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c733ef3bdcfe52a1a75564389bad4064352274036e7e234730526d155f04d914"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2858b2504c8697beb9357be01dc47ef86438cc1cb36ecb6991796d19475faa3e"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:d2cfac21e31e841d60dc28c0ec7d4ec47a35c608cb8906435d47ef83ffb22150"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:3228b7a51e3ed533f5472f54f70fd0b0a64c48dc1649a0f0e809bec312934d7a"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:dcc119db14757b0c7bce64042158307b9b1c76471e655751a61b57f5a0e4d78e"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:7d9b42127a6c0bdcc25c3dcf252bb3ddc70454fac593b1b6933ae091396deb13"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-win32.whl", hash = "sha256:df48a623c58180874d7407b4d9ec06a19b84ed47f60a3884345b1a5099c1818b"},
+    {file = "aiohttp-3.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:0b795072bb1bf87b8620120a6373a3c61bfcb8da7e5c2377f4bb23ff4f0b62c9"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:0d438c8ca703b1b714e82ed5b7a4412c82577040dadff479c08405e2a715564f"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8389d6044ee4e2037dca83e3f6994738550f6ee8cfb746762283fad9b932868f"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:3ea8c252d8df5e9166bcf3d9edced2af132f4ead8ac422eac723c5781063709a"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:78e2f18a82b88cbc37d22365cf8d2b879a492faedb3f2975adb4ed8dfe994d3a"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:df3a7b258cc230a65245167a202dd07320a5af05f3d41da1488ba0fa05bc9347"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:f326b3c1bbfda5b9308252ee0dcb30b612ee92b0e105d4abec70335fab5b1245"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5e479df4b2d0f8f02133b7e4430098699450e1b2a826438af6bec9a400530957"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-win32.whl", hash = "sha256:6d42debaf55450643146fabe4b6817bb2a55b23698b0434107e892a43117285e"},
+    {file = "aiohttp-3.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:c9c58b0b84055d8bc27b7df5a9d141df4ee6ff59821f922dd73155861282f6a3"},
+    {file = "aiohttp-3.7.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:f411cb22115cb15452d099fec0ee636b06cf81bfb40ed9c02d30c8dc2bc2e3d1"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:c1e0920909d916d3375c7a1fdb0b1c78e46170e8bb42792312b6eb6676b2f87f"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:59d11674964b74a81b149d4ceaff2b674b3b0e4d0f10f0be1533e49c4a28408b"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:41608c0acbe0899c852281978492f9ce2c6fbfaf60aff0cefc54a7c4516b822c"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:16a3cb5df5c56f696234ea9e65e227d1ebe9c18aa774d36ff42f532139066a5f"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:6ccc43d68b81c424e46192a778f97da94ee0630337c9bbe5b2ecc9b0c1c59001"},
+    {file = "aiohttp-3.7.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:d03abec50df423b026a5aa09656bd9d37f1e6a49271f123f31f9b8aed5dc3ea3"},
+    {file = "aiohttp-3.7.3-cp38-cp38-win32.whl", hash = "sha256:39f4b0a6ae22a1c567cb0630c30dd082481f95c13ca528dc501a7766b9c718c0"},
+    {file = "aiohttp-3.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:c68fdf21c6f3573ae19c7ee65f9ff185649a060c9a06535e9c3a0ee0bbac9235"},
+    {file = "aiohttp-3.7.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:710376bf67d8ff4500a31d0c207b8941ff4fba5de6890a701d71680474fe2a60"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2406dc1dda01c7f6060ab586e4601f18affb7a6b965c50a8c90ff07569cf782a"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:2a7b7640167ab536c3cb90cfc3977c7094f1c5890d7eeede8b273c175c3910fd"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:684850fb1e3e55c9220aad007f8386d8e3e477c4ec9211ae54d968ecdca8c6f9"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:1edfd82a98c5161497bbb111b2b70c0813102ad7e0aa81cbeb34e64c93863005"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:77149002d9386fae303a4a162e6bce75cc2161347ad2ba06c2f0182561875d45"},
+    {file = "aiohttp-3.7.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:756ae7efddd68d4ea7d89c636b703e14a0c686688d42f588b90778a3c2fc0564"},
+    {file = "aiohttp-3.7.3-cp39-cp39-win32.whl", hash = "sha256:3b0036c978cbcc4a4512278e98e3e6d9e6b834dc973206162eddf98b586ef1c6"},
+    {file = "aiohttp-3.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:e1b95972a0ae3f248a899cdbac92ba2e01d731225f566569311043ce2226f5e7"},
+    {file = "aiohttp-3.7.3.tar.gz", hash = "sha256:9c1a81af067e72261c9cbe33ea792893e83bc6aa987bfbd6fdc1e5e7b22777c4"},
 ]
 appdirs = [
     {file = "appdirs-1.4.4-py2.py3-none-any.whl", hash = "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"},
@@ -1965,8 +1929,8 @@ atomicwrites = [
     {file = "atomicwrites-1.4.0.tar.gz", hash = "sha256:ae70396ad1a434f9c7046fd2dd196fc04b12f9e91ffb859164193be8b6168a7a"},
 ]
 attrs = [
-    {file = "attrs-20.2.0-py2.py3-none-any.whl", hash = "sha256:fce7fc47dfc976152e82d53ff92fa0407700c21acd20886a13777a0d20e655dc"},
-    {file = "attrs-20.2.0.tar.gz", hash = "sha256:26b54ddbbb9ee1d34d5d3668dd37d6cf74990ab23c828c2888dccdceee395594"},
+    {file = "attrs-20.3.0-py2.py3-none-any.whl", hash = "sha256:31b2eced602aa8423c2aea9c76a724617ed67cf9513173fd3a4f03e3a929c7e6"},
+    {file = "attrs-20.3.0.tar.gz", hash = "sha256:832aa3cde19744e49938b91fea06d69ecb9e649c93ba974535d08ad92164f700"},
 ]
 bandit = [
     {file = "bandit-1.6.2-py2.py3-none-any.whl", hash = "sha256:336620e220cf2d3115877685e264477ff9d9abaeb0afe3dc7264f55fa17a3952"},
@@ -1990,54 +1954,52 @@ black = [
     {file = "black-19.10b0.tar.gz", hash = "sha256:c2edb73a08e9e0e6f65a0e6af18b059b8b1cdd5bef997d7a0b181df93dc81539"},
 ]
 certifi = [
-    {file = "certifi-2020.6.20-py2.py3-none-any.whl", hash = "sha256:8fc0819f1f30ba15bdb34cceffb9ef04d99f420f68eb75d901e9560b8749fc41"},
-    {file = "certifi-2020.6.20.tar.gz", hash = "sha256:5930595817496dd21bb8dc35dad090f1c2cd0adfaf21204bf6732ca5d8ee34d3"},
+    {file = "certifi-2020.11.8-py2.py3-none-any.whl", hash = "sha256:1f422849db327d534e3d0c5f02a263458c3955ec0aae4ff09b95f195c59f4edd"},
+    {file = "certifi-2020.11.8.tar.gz", hash = "sha256:f05def092c44fbf25834a51509ef6e631dc19765ab8a57b4e7ab85531f0a9cf4"},
 ]
 cffi = [
-    {file = "cffi-1.14.3-2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:3eeeb0405fd145e714f7633a5173318bd88d8bbfc3dd0a5751f8c4f70ae629bc"},
-    {file = "cffi-1.14.3-2-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:cb763ceceae04803adcc4e2d80d611ef201c73da32d8f2722e9d0ab0c7f10768"},
-    {file = "cffi-1.14.3-2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:44f60519595eaca110f248e5017363d751b12782a6f2bd6a7041cba275215f5d"},
-    {file = "cffi-1.14.3-2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:c53af463f4a40de78c58b8b2710ade243c81cbca641e34debf3396a9640d6ec1"},
-    {file = "cffi-1.14.3-2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:33c6cdc071ba5cd6d96769c8969a0531be2d08c2628a0143a10a7dcffa9719ca"},
-    {file = "cffi-1.14.3-2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c11579638288e53fc94ad60022ff1b67865363e730ee41ad5e6f0a17188b327a"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:3cb3e1b9ec43256c4e0f8d2837267a70b0e1ca8c4f456685508ae6106b1f504c"},
-    {file = "cffi-1.14.3-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:f0620511387790860b249b9241c2f13c3a80e21a73e0b861a2df24e9d6f56730"},
-    {file = "cffi-1.14.3-cp27-cp27m-win32.whl", hash = "sha256:005f2bfe11b6745d726dbb07ace4d53f057de66e336ff92d61b8c7e9c8f4777d"},
-    {file = "cffi-1.14.3-cp27-cp27m-win_amd64.whl", hash = "sha256:2f9674623ca39c9ebe38afa3da402e9326c245f0f5ceff0623dccdac15023e05"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:09e96138280241bd355cd585148dec04dbbedb4f46128f340d696eaafc82dd7b"},
-    {file = "cffi-1.14.3-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3363e77a6176afb8823b6e06db78c46dbc4c7813b00a41300a4873b6ba63b171"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:0ef488305fdce2580c8b2708f22d7785ae222d9825d3094ab073e22e93dfe51f"},
-    {file = "cffi-1.14.3-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0b1ad452cc824665ddc682400b62c9e4f5b64736a2ba99110712fdee5f2505c4"},
-    {file = "cffi-1.14.3-cp35-cp35m-win32.whl", hash = "sha256:85ba797e1de5b48aa5a8427b6ba62cf69607c18c5d4eb747604b7302f1ec382d"},
-    {file = "cffi-1.14.3-cp35-cp35m-win_amd64.whl", hash = "sha256:e66399cf0fc07de4dce4f588fc25bfe84a6d1285cc544e67987d22663393926d"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:15f351bed09897fbda218e4db5a3d5c06328862f6198d4fb385f3e14e19decb3"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4d7c26bfc1ea9f92084a1d75e11999e97b62d63128bcc90c3624d07813c52808"},
-    {file = "cffi-1.14.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:23e5d2040367322824605bc29ae8ee9175200b92cb5483ac7d466927a9b3d537"},
-    {file = "cffi-1.14.3-cp36-cp36m-win32.whl", hash = "sha256:a624fae282e81ad2e4871bdb767e2c914d0539708c0f078b5b355258293c98b0"},
-    {file = "cffi-1.14.3-cp36-cp36m-win_amd64.whl", hash = "sha256:de31b5164d44ef4943db155b3e8e17929707cac1e5bd2f363e67a56e3af4af6e"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f92cdecb618e5fa4658aeb97d5eb3d2f47aa94ac6477c6daf0f306c5a3b9e6b1"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:22399ff4870fb4c7ef19fff6eeb20a8bbf15571913c181c78cb361024d574579"},
-    {file = "cffi-1.14.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:f4eae045e6ab2bb54ca279733fe4eb85f1effda392666308250714e01907f394"},
-    {file = "cffi-1.14.3-cp37-cp37m-win32.whl", hash = "sha256:b0358e6fefc74a16f745afa366acc89f979040e0cbc4eec55ab26ad1f6a9bfbc"},
-    {file = "cffi-1.14.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6642f15ad963b5092d65aed022d033c77763515fdc07095208f15d3563003869"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2791f68edc5749024b4722500e86303a10d342527e1e3bcac47f35fbd25b764e"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:529c4ed2e10437c205f38f3691a68be66c39197d01062618c55f74294a4a4828"},
-    {file = "cffi-1.14.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8f0f1e499e4000c4c347a124fa6a27d37608ced4fe9f7d45070563b7c4c370c9"},
-    {file = "cffi-1.14.3-cp38-cp38-win32.whl", hash = "sha256:3b8eaf915ddc0709779889c472e553f0d3e8b7bdf62dab764c8921b09bf94522"},
-    {file = "cffi-1.14.3-cp38-cp38-win_amd64.whl", hash = "sha256:bbd2f4dfee1079f76943767fce837ade3087b578aeb9f69aec7857d5bf25db15"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:cc75f58cdaf043fe6a7a6c04b3b5a0e694c6a9e24050967747251fb80d7bce0d"},
-    {file = "cffi-1.14.3-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:bf39a9e19ce7298f1bd6a9758fa99707e9e5b1ebe5e90f2c3913a47bc548747c"},
-    {file = "cffi-1.14.3-cp39-cp39-win32.whl", hash = "sha256:d80998ed59176e8cba74028762fbd9b9153b9afc71ea118e63bbf5d4d0f9552b"},
-    {file = "cffi-1.14.3-cp39-cp39-win_amd64.whl", hash = "sha256:c150eaa3dadbb2b5339675b88d4573c1be3cb6f2c33a6c83387e10cc0bf05bd3"},
-    {file = "cffi-1.14.3.tar.gz", hash = "sha256:f92f789e4f9241cd262ad7a555ca2c648a98178a953af117ef7fad46aa1d5591"},
+    {file = "cffi-1.14.4-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:ebb253464a5d0482b191274f1c8bf00e33f7e0b9c66405fbffc61ed2c839c775"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:2c24d61263f511551f740d1a065eb0212db1dbbbbd241db758f5244281590c06"},
+    {file = "cffi-1.14.4-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:9f7a31251289b2ab6d4012f6e83e58bc3b96bd151f5b5262467f4bb6b34a7c26"},
+    {file = "cffi-1.14.4-cp27-cp27m-win32.whl", hash = "sha256:5cf4be6c304ad0b6602f5c4e90e2f59b47653ac1ed9c662ed379fe48a8f26b0c"},
+    {file = "cffi-1.14.4-cp27-cp27m-win_amd64.whl", hash = "sha256:f60567825f791c6f8a592f3c6e3bd93dd2934e3f9dac189308426bd76b00ef3b"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:c6332685306b6417a91b1ff9fae889b3ba65c2292d64bd9245c093b1b284809d"},
+    {file = "cffi-1.14.4-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:d9efd8b7a3ef378dd61a1e77367f1924375befc2eba06168b6ebfa903a5e59ca"},
+    {file = "cffi-1.14.4-cp35-cp35m-macosx_10_9_x86_64.whl", hash = "sha256:51a8b381b16ddd370178a65360ebe15fbc1c71cf6f584613a7ea08bfad946698"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1d2c4994f515e5b485fd6d3a73d05526aa0fcf248eb135996b088d25dfa1865b"},
+    {file = "cffi-1.14.4-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:af5c59122a011049aad5dd87424b8e65a80e4a6477419c0c1015f73fb5ea0293"},
+    {file = "cffi-1.14.4-cp35-cp35m-win32.whl", hash = "sha256:594234691ac0e9b770aee9fcdb8fa02c22e43e5c619456efd0d6c2bf276f3eb2"},
+    {file = "cffi-1.14.4-cp35-cp35m-win_amd64.whl", hash = "sha256:64081b3f8f6f3c3de6191ec89d7dc6c86a8a43911f7ecb422c60e90c70be41c7"},
+    {file = "cffi-1.14.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:f803eaa94c2fcda012c047e62bc7a51b0bdabda1cad7a92a522694ea2d76e49f"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:105abaf8a6075dc96c1fe5ae7aae073f4696f2905fde6aeada4c9d2926752362"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0638c3ae1a0edfb77c6765d487fee624d2b1ee1bdfeffc1f0b58c64d149e7eec"},
+    {file = "cffi-1.14.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7c6b1dece89874d9541fc974917b631406233ea0440d0bdfbb8e03bf39a49b3b"},
+    {file = "cffi-1.14.4-cp36-cp36m-win32.whl", hash = "sha256:155136b51fd733fa94e1c2ea5211dcd4c8879869008fc811648f16541bf99668"},
+    {file = "cffi-1.14.4-cp36-cp36m-win_amd64.whl", hash = "sha256:6bc25fc545a6b3d57b5f8618e59fc13d3a3a68431e8ca5fd4c13241cd70d0009"},
+    {file = "cffi-1.14.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:a7711edca4dcef1a75257b50a2fbfe92a65187c47dab5a0f1b9b332c5919a3fb"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:00e28066507bfc3fe865a31f325c8391a1ac2916219340f87dfad602c3e48e5d"},
+    {file = "cffi-1.14.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:798caa2a2384b1cbe8a2a139d80734c9db54f9cc155c99d7cc92441a23871c03"},
+    {file = "cffi-1.14.4-cp37-cp37m-win32.whl", hash = "sha256:00a1ba5e2e95684448de9b89888ccd02c98d512064b4cb987d48f4b40aa0421e"},
+    {file = "cffi-1.14.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9cc46bc107224ff5b6d04369e7c595acb700c3613ad7bcf2e2012f62ece80c35"},
+    {file = "cffi-1.14.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:df5169c4396adc04f9b0a05f13c074df878b6052430e03f50e68adf3a57aa28d"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:9ffb888f19d54a4d4dfd4b3f29bc2c16aa4972f1c2ab9c4ab09b8ab8685b9c2b"},
+    {file = "cffi-1.14.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:8d6603078baf4e11edc4168a514c5ce5b3ba6e3e9c374298cb88437957960a53"},
+    {file = "cffi-1.14.4-cp38-cp38-win32.whl", hash = "sha256:b4e248d1087abf9f4c10f3c398896c87ce82a9856494a7155823eb45a892395d"},
+    {file = "cffi-1.14.4-cp38-cp38-win_amd64.whl", hash = "sha256:ec80dc47f54e6e9a78181ce05feb71a0353854cc26999db963695f950b5fb375"},
+    {file = "cffi-1.14.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:840793c68105fe031f34d6a086eaea153a0cd5c491cde82a74b420edd0a2b909"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:b18e0a9ef57d2b41f5c68beefa32317d286c3d6ac0484efd10d6e07491bb95dd"},
+    {file = "cffi-1.14.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:045d792900a75e8b1e1b0ab6787dd733a8190ffcf80e8c8ceb2fb10a29ff238a"},
+    {file = "cffi-1.14.4-cp39-cp39-win32.whl", hash = "sha256:ba4e9e0ae13fc41c6b23299545e5ef73055213e466bd107953e4a013a5ddd7e3"},
+    {file = "cffi-1.14.4-cp39-cp39-win_amd64.whl", hash = "sha256:f032b34669220030f905152045dfa27741ce1a6db3324a5bc0b96b6c7420c87b"},
+    {file = "cffi-1.14.4.tar.gz", hash = "sha256:1a465cbe98a7fd391d47dce4b8f7e5b921e6cd805ef421d04f5f66ba8f06086c"},
 ]
 chardet = [
     {file = "chardet-3.0.4-py2.py3-none-any.whl", hash = "sha256:fc323ffcaeaed0e0a02bf4d117757b98aed530d9ed4531e3e15460124c106691"},
     {file = "chardet-3.0.4.tar.gz", hash = "sha256:84ab92ed1c4d4f16916e05906b6b75a6c0fb5db821cc65e70cbd64a3e2a5eaae"},
 ]
 ciscoconfparse = [
-    {file = "ciscoconfparse-1.5.19-py3-none-any.whl", hash = "sha256:b5b406407174ac3239ec07e21f62b003175dd4db770d157c5b2c05345aa08140"},
-    {file = "ciscoconfparse-1.5.19.tar.gz", hash = "sha256:6aa1644224234a09f12224ffa616847bce02e6c2c15d2dd53857a07556d4ae20"},
+    {file = "ciscoconfparse-1.5.20-py3-none-any.whl", hash = "sha256:e59a042692dd37cf5987546528cd24525b9735a4a6934c33d7632d85e88ad84d"},
+    {file = "ciscoconfparse-1.5.20.tar.gz", hash = "sha256:7daaf6d98b45f7881800d911812db366f216322024903222c013e0f6d3f33aff"},
 ]
 click = [
     {file = "click-7.1.2-py2.py3-none-any.whl", hash = "sha256:dacca89f4bfadd5de3d7489b7c8a566eee0d3676333fbb50030263894c38c0dc"},
@@ -2055,28 +2017,28 @@ configargparse = [
     {file = "ConfigArgParse-0.15.2.tar.gz", hash = "sha256:558738aff623d6667aa5b85df6093ad3828867de8a82b66a6d458fb42567beb3"},
 ]
 cryptography = [
-    {file = "cryptography-3.2-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:9a8580c9afcdcddabbd064c0a74f337af74ff4529cdf3a12fa2e9782d677a2e5"},
-    {file = "cryptography-3.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:7ef41304bf978f33cfb6f43ca13bb0faac0c99cda33693aa20ad4f5e34e8cb8f"},
-    {file = "cryptography-3.2-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:87c2fffd61e934bc0e2c927c3764c20b22d7f5f7f812ee1a477de4c89b044ca6"},
-    {file = "cryptography-3.2-cp27-cp27m-win32.whl", hash = "sha256:6e8a3c7c45101a7eeee93102500e1b08f2307c717ff553fcb3c1127efc9b6917"},
-    {file = "cryptography-3.2-cp27-cp27m-win_amd64.whl", hash = "sha256:52a47e60953679eea0b4d490ca3c241fb1b166a7b161847ef4667dfd49e7699d"},
-    {file = "cryptography-3.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:6a8f64ed096d13f92d1f601a92d9fd1f1025dc73a2ca1ced46dcf5e0d4930943"},
-    {file = "cryptography-3.2-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:3e17d02941c0f169c5b877597ca8be895fca0e5e3eb882526a74aa4804380a98"},
-    {file = "cryptography-3.2-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:d1cbc3426e6150583b22b517ef3720036d7e3152d428c864ff0f3fcad2b97591"},
-    {file = "cryptography-3.2-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:22f8251f68953553af4f9c11ec5f191198bc96cff9f0ac5dd5ff94daede0ee6d"},
-    {file = "cryptography-3.2-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:f2aa3f8ba9e2e3fd49bd3de743b976ab192fbf0eb0348cebde5d2a9de0090a9f"},
-    {file = "cryptography-3.2-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:9a07e6d255053674506091d63ab4270a119e9fc83462c7ab1dbcb495b76307af"},
-    {file = "cryptography-3.2-cp35-cp35m-win32.whl", hash = "sha256:f0e3986f6cce007216b23c490f093f35ce2068f3c244051e559f647f6731b7ae"},
-    {file = "cryptography-3.2-cp35-cp35m-win_amd64.whl", hash = "sha256:284e275e3c099a80831f9898fb5c9559120d27675c3521278faba54e584a7832"},
-    {file = "cryptography-3.2-cp36-abi3-win32.whl", hash = "sha256:f01c9116bfb3ad2831e125a73dcd957d173d6ddca7701528eff1e7d97972872c"},
-    {file = "cryptography-3.2-cp36-abi3-win_amd64.whl", hash = "sha256:bd80bc156d3729b38cb227a5a76532aef693b7ac9e395eea8063ee50ceed46a5"},
-    {file = "cryptography-3.2-cp36-cp36m-win32.whl", hash = "sha256:8f0fd8b0751d75c4483c534b209e39e918f0d14232c0d8a2a76e687f64ced831"},
-    {file = "cryptography-3.2-cp36-cp36m-win_amd64.whl", hash = "sha256:8a0866891326d3badb17c5fd3e02c926b635e8923fa271b4813cd4d972a57ff3"},
-    {file = "cryptography-3.2-cp37-cp37m-win32.whl", hash = "sha256:57b8c1ed13b8aa386cabbfde3be175d7b155682470b0e259fecfe53850967f8a"},
-    {file = "cryptography-3.2-cp37-cp37m-win_amd64.whl", hash = "sha256:88069392cd9a1e68d2cfd5c3a2b0d72a44ef3b24b8977a4f7956e9e3c4c9477a"},
-    {file = "cryptography-3.2-cp38-cp38-win32.whl", hash = "sha256:fb70a4cedd69dc52396ee114416a3656e011fb0311fca55eb55c7be6ed9c8aef"},
-    {file = "cryptography-3.2-cp38-cp38-win_amd64.whl", hash = "sha256:e15ac84dcdb89f92424cbaca4b0b34e211e7ce3ee7b0ec0e4f3c55cee65fae5a"},
-    {file = "cryptography-3.2.tar.gz", hash = "sha256:e4789b84f8dedf190148441f7c5bfe7244782d9cbb194a36e17b91e7d3e1cca9"},
+    {file = "cryptography-3.2.1-cp27-cp27m-macosx_10_10_x86_64.whl", hash = "sha256:6dc59630ecce8c1f558277ceb212c751d6730bd12c80ea96b4ac65637c4f55e7"},
+    {file = "cryptography-3.2.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:75e8e6684cf0034f6bf2a97095cb95f81537b12b36a8fedf06e73050bb171c2d"},
+    {file = "cryptography-3.2.1-cp27-cp27m-manylinux2010_x86_64.whl", hash = "sha256:4e7268a0ca14536fecfdf2b00297d4e407da904718658c1ff1961c713f90fd33"},
+    {file = "cryptography-3.2.1-cp27-cp27m-win32.whl", hash = "sha256:7117319b44ed1842c617d0a452383a5a052ec6aa726dfbaffa8b94c910444297"},
+    {file = "cryptography-3.2.1-cp27-cp27m-win_amd64.whl", hash = "sha256:a733671100cd26d816eed39507e585c156e4498293a907029969234e5e634bc4"},
+    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:a75f306a16d9f9afebfbedc41c8c2351d8e61e818ba6b4c40815e2b5740bb6b8"},
+    {file = "cryptography-3.2.1-cp27-cp27mu-manylinux2010_x86_64.whl", hash = "sha256:5849d59358547bf789ee7e0d7a9036b2d29e9a4ddf1ce5e06bb45634f995c53e"},
+    {file = "cryptography-3.2.1-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:bd717aa029217b8ef94a7d21632a3bb5a4e7218a4513d2521c2a2fd63011e98b"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:efe15aca4f64f3a7ea0c09c87826490e50ed166ce67368a68f315ea0807a20df"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux2010_x86_64.whl", hash = "sha256:32434673d8505b42c0de4de86da8c1620651abd24afe91ae0335597683ed1b77"},
+    {file = "cryptography-3.2.1-cp35-abi3-manylinux2014_aarch64.whl", hash = "sha256:7b8d9d8d3a9bd240f453342981f765346c87ade811519f98664519696f8e6ab7"},
+    {file = "cryptography-3.2.1-cp35-cp35m-win32.whl", hash = "sha256:d3545829ab42a66b84a9aaabf216a4dce7f16dbc76eb69be5c302ed6b8f4a29b"},
+    {file = "cryptography-3.2.1-cp35-cp35m-win_amd64.whl", hash = "sha256:a4e27ed0b2504195f855b52052eadcc9795c59909c9d84314c5408687f933fc7"},
+    {file = "cryptography-3.2.1-cp36-abi3-win32.whl", hash = "sha256:13b88a0bd044b4eae1ef40e265d006e34dbcde0c2f1e15eb9896501b2d8f6c6f"},
+    {file = "cryptography-3.2.1-cp36-abi3-win_amd64.whl", hash = "sha256:07ca431b788249af92764e3be9a488aa1d39a0bc3be313d826bbec690417e538"},
+    {file = "cryptography-3.2.1-cp36-cp36m-win32.whl", hash = "sha256:a035a10686532b0587d58a606004aa20ad895c60c4d029afa245802347fab57b"},
+    {file = "cryptography-3.2.1-cp36-cp36m-win_amd64.whl", hash = "sha256:d26a2557d8f9122f9bf445fc7034242f4375bd4e95ecda007667540270965b13"},
+    {file = "cryptography-3.2.1-cp37-cp37m-win32.whl", hash = "sha256:545a8550782dda68f8cdc75a6e3bf252017aa8f75f19f5a9ca940772fc0cb56e"},
+    {file = "cryptography-3.2.1-cp37-cp37m-win_amd64.whl", hash = "sha256:55d0b896631412b6f0c7de56e12eb3e261ac347fbaa5d5e705291a9016e5f8cb"},
+    {file = "cryptography-3.2.1-cp38-cp38-win32.whl", hash = "sha256:3cd75a683b15576cfc822c7c5742b3276e50b21a06672dc3a800a2d5da4ecd1b"},
+    {file = "cryptography-3.2.1-cp38-cp38-win_amd64.whl", hash = "sha256:d25cecbac20713a7c3bc544372d42d8eafa89799f492a43b79e1dfd650484851"},
+    {file = "cryptography-3.2.1.tar.gz", hash = "sha256:d3d5e10be0cf2a12214ddee45c6bd203dab435e3d83b4560c03066eda600bfe3"},
 ]
 deepdiff = [
     {file = "deepdiff-5.0.2-py3-none-any.whl", hash = "sha256:273b18d32bb9b956548290b2e3ddf79c515def2dd5738965f4348ae813e710c5"},
@@ -2091,7 +2053,8 @@ diffsync = [
     {file = "diffsync-1.0.0.tar.gz", hash = "sha256:9f7654f3bd03d3744fbc67b77ccaf53ae1059bf09c93ed6096a2bd75169a0b76"},
 ]
 dill = [
-    {file = "dill-0.3.2.zip", hash = "sha256:6e12da0d8e49c220e8d6e97ee8882002e624f1160289ce85ec2cc0a5246b3a2e"},
+    {file = "dill-0.3.3-py2.py3-none-any.whl", hash = "sha256:78370261be6ea49037ace8c17e0b7dd06d0393af6513cc23f9b222d9367ce389"},
+    {file = "dill-0.3.3.zip", hash = "sha256:efb7f6cb65dba7087c1e111bb5390291ba3616741f96840bfc75792a1a9b5ded"},
 ]
 distro = [
     {file = "distro-1.5.0-py2.py3-none-any.whl", hash = "sha256:df74eed763e18d10d0da624258524ae80486432cd17392d9c3d96f5e83cd2799"},
@@ -2113,53 +2076,39 @@ future = [
     {file = "future-0.18.2.tar.gz", hash = "sha256:b1bead90b70cf6ec3f0710ae53a525360fa360d306a86583adc6bf83a4db537d"},
 ]
 genie = [
-    {file = "genie-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:1232bf36926992bb1cccd3a0aaaa87615d4fc417da25a64011063e44b9750fc3"},
-    {file = "genie-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:7cf6d23d1725c0657c390089a63843100a24688ad13aa7a91023fa3ad7b78da7"},
-    {file = "genie-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a8dbb824250284fdbe24ecf2de9c9818b577f9097d317655c4e603c8fb09bfd3"},
-    {file = "genie-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:b6ba067bfdc052f546085c30ae924dc40e2a4980274edc695973875b87a48f08"},
-    {file = "genie-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c3c2724e06fa3e866cdef6168b46a977d5453f2d7cca43f276684611ee014215"},
-    {file = "genie-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:848fec1bafa91c80e44f26281167d65baff9019ae0d899fbc6c413990abd0b29"},
-    {file = "genie-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:9e46d90882972aa8e736fdb4a0c2afe75948f817ac30d162549f7098a5a3ded0"},
-    {file = "genie-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2eb259aafa5bb2c55de52b7a2fb59f355e93d3b75d641a02e43ad73556ec5b39"},
-    {file = "genie-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e4bc7ef827d6e27316c58aff2d3ca5edbc09ddf685d6da8efd14b403ec350958"},
-    {file = "genie-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:393c344d8959e8d030e4cbbacfbf3154971f8681fca9efb1451ef68f38da870f"},
-    {file = "genie-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4a63b8e1e0be69bc1d6191b01787f7ea0446d30a9e032b3ccb5952e54da072d8"},
-    {file = "genie-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:134ca4bd8f0345cd7a6028c8eb795a113cccfb79b7ef3662c1612875cfe57f17"},
+    {file = "genie-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:5b8176ffa99745d9aab226a0e2c8b924f53e093ae5218c41a59721315e7a7374"},
+    {file = "genie-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:fa85d956e8dda06ec416d3a702585e3e98f472953e47eca8363b33fd0a776ef2"},
+    {file = "genie-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:144281210d89149ba1855eb0d6723b1d1e4cc294df7edf057e485c34470b060f"},
+    {file = "genie-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:d1a7f585be35d2781e707a6c5e99c57ead42fb68f867125e991df0590f3d5e10"},
+    {file = "genie-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:10ad24bfc686824d7d566c84ecdb7744d9e5d908667e4ff6119b842408368ad1"},
+    {file = "genie-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bc2a9c25fdcfae8e258a94d510bb865e8c5078b34027fa7b94d4478e16ffb090"},
+    {file = "genie-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:5e5f959ec15462714adab4cc3a6abee32c87ee6cb790bd2eb137d7245ddc0db7"},
+    {file = "genie-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6355f08d2abf13c53eb3622c203b249397b8bf0046073a9e24d8d2e4fcb061b6"},
+    {file = "genie-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:db83aa0fc9ef97cd0e97165fface80aca65e013e5954c7857c88c89acbe02b50"},
+    {file = "genie-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:1c3c5e8d29a05a60ba9dd99bbc85ab7861be9dc1b710b2b6a38ec796094ae5fe"},
+    {file = "genie-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b0450d09e9a5049b32a03e4d100e85b18e14cba5173fb9e040daac9f4fad9b12"},
+    {file = "genie-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a1de00c4ba1a215208fc92b7de9625c46a15f984700a74571f3e6dea8a8916db"},
 ]
 "genie.libs.clean" = [
-    {file = "genie.libs.clean-20.9.1-py3-none-any.whl", hash = "sha256:162ebbb891381bcaa280fdd2fbf7885f55fd74c71030b2c9a5e0d6957067e7d3"},
+    {file = "genie.libs.clean-20.10.1-py3-none-any.whl", hash = "sha256:21a227373d285ba7e13adf32c4c855b8e33cc4bc37950ebee39d2abea3a765b5"},
 ]
 "genie.libs.conf" = [
-    {file = "genie.libs.conf-20.9-py3-none-any.whl", hash = "sha256:558de4afa0585f23e1613d3c6902e3d234d415df0eee156765cf1f82c925b51e"},
+    {file = "genie.libs.conf-20.10-py3-none-any.whl", hash = "sha256:2704b11017a4619c6fa107b439dd1761cf7f35e7c2ca2767b04175777a7c1213"},
 ]
 "genie.libs.filetransferutils" = [
-    {file = "genie.libs.filetransferutils-20.9-py3-none-any.whl", hash = "sha256:72360be7839a8d07aa05f0719ab52adb654c5a316514cec806f4af8d6ab38ecc"},
+    {file = "genie.libs.filetransferutils-20.10-py3-none-any.whl", hash = "sha256:10431e36344c9d5d0234c7f4741d569d2d58eacea7b117be6fce1aff90e8e9ce"},
 ]
 "genie.libs.health" = [
-    {file = "genie.libs.health-20.9-py3-none-any.whl", hash = "sha256:7829bec3316e73183682ba6f1504c143545c817338fb9ee8c10a88a2430195eb"},
+    {file = "genie.libs.health-20.10.1-py3-none-any.whl", hash = "sha256:3ffe5afc98e7a09c28d1a7e78d87d70f2eb84702d07d2655df958b67f9a3aa7f"},
 ]
 "genie.libs.ops" = [
-    {file = "genie.libs.ops-20.9-py3-none-any.whl", hash = "sha256:ff114e0cc393d72bbb86ff9a10f46e642f15adc7e061a716b6be511fb35b7fb2"},
+    {file = "genie.libs.ops-20.10-py3-none-any.whl", hash = "sha256:c47bb18a0d7ebbd924b3027bc9f7e088add7ab13383f9dd1c7b6876edfacbc34"},
 ]
 "genie.libs.parser" = [
-    {file = "genie.libs.parser-20.9-py3-none-any.whl", hash = "sha256:9af6d84bd6915e3935b34d842e99d8a061b63d740b952127f8ba47a9c9c25a8c"},
+    {file = "genie.libs.parser-20.10-py3-none-any.whl", hash = "sha256:9c405806e61c0ee8b4f12c38e7aedd5c0975038656dada3325f43f39caa981d3"},
 ]
 "genie.libs.sdk" = [
-    {file = "genie.libs.sdk-20.9.1-py3-none-any.whl", hash = "sha256:ebfe2211b8788c85937808f381c1b71a0cf80852210b26cee40287622ace2930"},
-]
-"genie.metaparser" = [
-    {file = "genie.metaparser-19.12-cp34-cp34m-macosx_10_10_x86_64.whl", hash = "sha256:e392672c06a5fc8c9b6f64a12607843b62aae47e049a4215f0545e3aabbbbbbf"},
-    {file = "genie.metaparser-19.12-cp34-cp34m-manylinux1_i686.whl", hash = "sha256:b2baec73cd8c99b9fb1ae0e4fe7a7204298c4164a94125600ac60d6b9677d735"},
-    {file = "genie.metaparser-19.12-cp34-cp34m-manylinux1_x86_64.whl", hash = "sha256:0e98bac738d097350540281ee21b0f0ae9dd76129ac35e8fe49a464f5a741955"},
-    {file = "genie.metaparser-19.12-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:996cbf1ed22899c897eb863092e47ca10ddc8eec51130540c57d15b7b42279a5"},
-    {file = "genie.metaparser-19.12-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:07550995b0f88a3959cb57220bd89b659b5b85c26d7ccedcb10ed40632dad5c5"},
-    {file = "genie.metaparser-19.12-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:bccf0bd44a156fcc4c07921552c648a7822bcf68016aaa565e8d8902878d6d0e"},
-    {file = "genie.metaparser-19.12-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:f2fdd8b398df2bef772f9d90f39805a76ff9f23c5d37962896451c0282f920ed"},
-    {file = "genie.metaparser-19.12-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bed02f46b6ed3bf5f9fbce784d698a8215f86beba381734609469033fa8788eb"},
-    {file = "genie.metaparser-19.12-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:b41fc769f46ed4ddf465fdc1ae93dc77cb86654085224c08d3f372a8732338cd"},
-    {file = "genie.metaparser-19.12-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:43ac6c609b2b5a3a2876f7a5b3408d95c3add895f56357b51bc42ab8f96ce431"},
-    {file = "genie.metaparser-19.12-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:452d3a05156921c5d9aa2c891a8beff9c613cdfc066cc851194ac1864577e0c1"},
-    {file = "genie.metaparser-19.12-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d26ed8a737009c4fd7cfabff4e0d78f02b9ae27ccdc801fc9e8c91ca4d2cc51c"},
+    {file = "genie.libs.sdk-20.10-py3-none-any.whl", hash = "sha256:f004865d1d6a202c8700d67406790cf41c8e5b25f550ebd963e065f3eddc10bc"},
 ]
 gitdb = [
     {file = "gitdb-4.0.5-py3-none-any.whl", hash = "sha256:91f36bfb1ab7949b3b40e23736db18231bf7593edada2ba5c3a174a7b23657ac"},
@@ -2174,8 +2123,8 @@ idna = [
     {file = "idna-2.10.tar.gz", hash = "sha256:b307872f855b18632ce0c21c5e45be78c0ea7ae4c15c828c20788b26921eb3f6"},
 ]
 importlib-metadata = [
-    {file = "importlib_metadata-2.0.0-py2.py3-none-any.whl", hash = "sha256:cefa1a2f919b866c5beb7c9f7b0ebb4061f30a8a9bf16d609b000e2dfaceb9c3"},
-    {file = "importlib_metadata-2.0.0.tar.gz", hash = "sha256:77a540690e24b0305878c37ffd421785a6f7e53c8b5720d211b211de8d0e95da"},
+    {file = "importlib_metadata-3.1.1-py3-none-any.whl", hash = "sha256:6112e21359ef8f344e7178aa5b72dc6e62b38b0d008e6d3cb212c5b84df72013"},
+    {file = "importlib_metadata-3.1.1.tar.gz", hash = "sha256:b0c2d3b226157ae4517d9625decf63591461c66b3a808c2666d538946519d170"},
 ]
 invoke = [
     {file = "invoke-1.4.1-py2-none-any.whl", hash = "sha256:93e12876d88130c8e0d7fd6618dd5387d6b36da55ad541481dfa5e001656f134"},
@@ -2195,19 +2144,15 @@ jinja2 = [
     {file = "Jinja2-2.11.2.tar.gz", hash = "sha256:89aab215427ef59c34ad58735269eb58b1a5808103067f7bb9d5836c651b3bb0"},
 ]
 jsonpickle = [
-    {file = "jsonpickle-1.4.1-py2.py3-none-any.whl", hash = "sha256:8919c166bac0574e3d74425c7559434062002d9dfc0ac2afa6dc746ba4a19439"},
-    {file = "jsonpickle-1.4.1.tar.gz", hash = "sha256:e8d4b7cd0bd6826001a74377df1079a76ad8bae0f909282de2554164c837c8ba"},
-]
-jsonschema = [
-    {file = "jsonschema-3.2.0-py2.py3-none-any.whl", hash = "sha256:4e5b3cf8216f577bee9ce139cbe72eca3ea4f292ec60928ff24758ce626cd163"},
-    {file = "jsonschema-3.2.0.tar.gz", hash = "sha256:c8a85b28d377cc7737e46e2d9f2b4f44ee3c0e1deac6bf46ddefc7187d30797a"},
+    {file = "jsonpickle-1.4.2-py2.py3-none-any.whl", hash = "sha256:2ac5863099864c63d7f0c367af5e512c94f3384977dd367f2eae5f2303f7b92c"},
+    {file = "jsonpickle-1.4.2.tar.gz", hash = "sha256:c9b99b28a9e6a3043ec993552db79f4389da11afcb1d0246d93c79f4b5e64062"},
 ]
 junit-xml = [
     {file = "junit_xml-1.9-py2.py3-none-any.whl", hash = "sha256:ec5ca1a55aefdd76d28fcc0b135251d156c7106fa979686a4b48d62b761b4732"},
 ]
 junos-eznc = [
-    {file = "junos-eznc-2.5.3.tar.gz", hash = "sha256:521659fe94da796897abc16773c3d84fa44d3e1f5386c71fbaef44cb80159855"},
-    {file = "junos_eznc-2.5.3-py2.py3-none-any.whl", hash = "sha256:fa9ca3893902deacf737adfb8e37447d692eba0c60201f5bf141c8071849736a"},
+    {file = "junos-eznc-2.5.4.tar.gz", hash = "sha256:bf036d0af9ee5c5e4f517cb5fc902fe891fa120e18f459805862c53d4a97193a"},
+    {file = "junos_eznc-2.5.4-py2.py3-none-any.whl", hash = "sha256:e05c36d56d8b8d13b1fb3bb763828bb3ee80fa1dcadc3a6762e8e2568504676d"},
 ]
 lazy-object-proxy = [
     {file = "lazy-object-proxy-1.4.3.tar.gz", hash = "sha256:f3900e8a5de27447acbf900b4750b0ddfd7ec1ea7fbaf11dfa911141bc522af0"},
@@ -2233,43 +2178,43 @@ lazy-object-proxy = [
     {file = "lazy_object_proxy-1.4.3-cp38-cp38-win_amd64.whl", hash = "sha256:59f79fef100b09564bc2df42ea2d8d21a64fdcda64979c0fa3db7bdaabaf6239"},
 ]
 lxml = [
-    {file = "lxml-4.6.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:4b7572145054330c8e324a72d808c8c8fbe12be33368db28c39a255ad5f7fb51"},
-    {file = "lxml-4.6.1-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:302160eb6e9764168e01d8c9ec6becddeb87776e81d3fcb0d97954dd51d48e0a"},
-    {file = "lxml-4.6.1-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:d4ad7fd3269281cb471ad6c7bafca372e69789540d16e3755dd717e9e5c9d82f"},
-    {file = "lxml-4.6.1-cp27-cp27m-win32.whl", hash = "sha256:189ad47203e846a7a4951c17694d845b6ade7917c47c64b29b86526eefc3adf5"},
-    {file = "lxml-4.6.1-cp27-cp27m-win_amd64.whl", hash = "sha256:56eff8c6fb7bc4bcca395fdff494c52712b7a57486e4fbde34c31bb9da4c6cc4"},
-    {file = "lxml-4.6.1-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:23c83112b4dada0b75789d73f949dbb4e8f29a0a3511647024a398ebd023347b"},
-    {file = "lxml-4.6.1-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:0e89f5d422988c65e6936e4ec0fe54d6f73f3128c80eb7ecc3b87f595523607b"},
-    {file = "lxml-4.6.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:2358809cc64394617f2719147a58ae26dac9e21bae772b45cfb80baa26bfca5d"},
-    {file = "lxml-4.6.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:be1ebf9cc25ab5399501c9046a7dcdaa9e911802ed0e12b7d620cd4bbf0518b3"},
-    {file = "lxml-4.6.1-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:4fff34721b628cce9eb4538cf9a73d02e0f3da4f35a515773cce6f5fe413b360"},
-    {file = "lxml-4.6.1-cp35-cp35m-win32.whl", hash = "sha256:475325e037fdf068e0c2140b818518cf6bc4aa72435c407a798b2db9f8e90810"},
-    {file = "lxml-4.6.1-cp35-cp35m-win_amd64.whl", hash = "sha256:f98b6f256be6cec8dd308a8563976ddaff0bdc18b730720f6f4bee927ffe926f"},
-    {file = "lxml-4.6.1-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:be7c65e34d1b50ab7093b90427cbc488260e4b3a38ef2435d65b62e9fa3d798a"},
-    {file = "lxml-4.6.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d18331ea905a41ae71596502bd4c9a2998902328bbabd29e3d0f5f8569fabad1"},
-    {file = "lxml-4.6.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3d9b2b72eb0dbbdb0e276403873ecfae870599c83ba22cadff2db58541e72856"},
-    {file = "lxml-4.6.1-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d20d32cbb31d731def4b1502294ca2ee99f9249b63bc80e03e67e8f8e126dea8"},
-    {file = "lxml-4.6.1-cp36-cp36m-win32.whl", hash = "sha256:d182eada8ea0de61a45a526aa0ae4bcd222f9673424e65315c35820291ff299c"},
-    {file = "lxml-4.6.1-cp36-cp36m-win_amd64.whl", hash = "sha256:c0dac835c1a22621ffa5e5f999d57359c790c52bbd1c687fe514ae6924f65ef5"},
-    {file = "lxml-4.6.1-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d84d741c6e35c9f3e7406cb7c4c2e08474c2a6441d59322a00dcae65aac6315d"},
-    {file = "lxml-4.6.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8862d1c2c020cb7a03b421a9a7b4fe046a208db30994fc8ff68c627a7915987f"},
-    {file = "lxml-4.6.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3a7a380bfecc551cfd67d6e8ad9faa91289173bdf12e9cfafbd2bdec0d7b1ec1"},
-    {file = "lxml-4.6.1-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:2d6571c48328be4304aee031d2d5046cbc8aed5740c654575613c5a4f5a11311"},
-    {file = "lxml-4.6.1-cp37-cp37m-win32.whl", hash = "sha256:803a80d72d1f693aa448566be46ffd70882d1ad8fc689a2e22afe63035eb998a"},
-    {file = "lxml-4.6.1-cp37-cp37m-win_amd64.whl", hash = "sha256:24e811118aab6abe3ce23ff0d7d38932329c513f9cef849d3ee88b0f848f2aa9"},
-    {file = "lxml-4.6.1-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:2e311a10f3e85250910a615fe194839a04a0f6bc4e8e5bb5cac221344e3a7891"},
-    {file = "lxml-4.6.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:a71400b90b3599eb7bf241f947932e18a066907bf84617d80817998cee81e4bf"},
-    {file = "lxml-4.6.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:211b3bcf5da70c2d4b84d09232534ad1d78320762e2c59dedc73bf01cb1fc45b"},
-    {file = "lxml-4.6.1-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:e65c221b2115a91035b55a593b6eb94aa1206fa3ab374f47c6dc10d364583ff9"},
-    {file = "lxml-4.6.1-cp38-cp38-win32.whl", hash = "sha256:d6f8c23f65a4bfe4300b85f1f40f6c32569822d08901db3b6454ab785d9117cc"},
-    {file = "lxml-4.6.1-cp38-cp38-win_amd64.whl", hash = "sha256:573b2f5496c7e9f4985de70b9bbb4719ffd293d5565513e04ac20e42e6e5583f"},
-    {file = "lxml-4.6.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:098fb713b31050463751dcc694878e1d39f316b86366fb9fe3fbbe5396ac9fab"},
-    {file = "lxml-4.6.1-cp39-cp39-manylinux1_i686.whl", hash = "sha256:1d87936cb5801c557f3e981c9c193861264c01209cb3ad0964a16310ca1b3301"},
-    {file = "lxml-4.6.1-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:2d5896ddf5389560257bbe89317ca7bcb4e54a02b53a3e572e1ce4226512b51b"},
-    {file = "lxml-4.6.1-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:9b06690224258db5cd39a84e993882a6874676f5de582da57f3df3a82ead9174"},
-    {file = "lxml-4.6.1-cp39-cp39-win32.whl", hash = "sha256:bb252f802f91f59767dcc559744e91efa9df532240a502befd874b54571417bd"},
-    {file = "lxml-4.6.1-cp39-cp39-win_amd64.whl", hash = "sha256:7ecaef52fd9b9535ae5f01a1dd2651f6608e4ec9dc136fc4dfe7ebe3c3ddb230"},
-    {file = "lxml-4.6.1.tar.gz", hash = "sha256:c152b2e93b639d1f36ec5a8ca24cde4a8eefb2b6b83668fcd8e83a67badcb367"},
+    {file = "lxml-4.6.2-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:a9d6bc8642e2c67db33f1247a77c53476f3a166e09067c0474facb045756087f"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:791394449e98243839fa822a637177dd42a95f4883ad3dec2a0ce6ac99fb0a9d"},
+    {file = "lxml-4.6.2-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:68a5d77e440df94011214b7db907ec8f19e439507a70c958f750c18d88f995d2"},
+    {file = "lxml-4.6.2-cp27-cp27m-win32.whl", hash = "sha256:fc37870d6716b137e80d19241d0e2cff7a7643b925dfa49b4c8ebd1295eb506e"},
+    {file = "lxml-4.6.2-cp27-cp27m-win_amd64.whl", hash = "sha256:69a63f83e88138ab7642d8f61418cf3180a4d8cd13995df87725cb8b893e950e"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:42ebca24ba2a21065fb546f3e6bd0c58c3fe9ac298f3a320147029a4850f51a2"},
+    {file = "lxml-4.6.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:f83d281bb2a6217cd806f4cf0ddded436790e66f393e124dfe9731f6b3fb9afe"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:535f067002b0fd1a4e5296a8f1bf88193080ff992a195e66964ef2a6cfec5388"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:366cb750140f221523fa062d641393092813b81e15d0e25d9f7c6025f910ee80"},
+    {file = "lxml-4.6.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:97db258793d193c7b62d4e2586c6ed98d51086e93f9a3af2b2034af01450a74b"},
+    {file = "lxml-4.6.2-cp35-cp35m-win32.whl", hash = "sha256:648914abafe67f11be7d93c1a546068f8eff3c5fa938e1f94509e4a5d682b2d8"},
+    {file = "lxml-4.6.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e751e77006da34643ab782e4a5cc21ea7b755551db202bc4d3a423b307db780"},
+    {file = "lxml-4.6.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:681d75e1a38a69f1e64ab82fe4b1ed3fd758717bed735fb9aeaa124143f051af"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:127f76864468d6630e1b453d3ffbbd04b024c674f55cf0a30dc2595137892d37"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4fb85c447e288df535b17ebdebf0ec1cf3a3f1a8eba7e79169f4f37af43c6b98"},
+    {file = "lxml-4.6.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:5be4a2e212bb6aa045e37f7d48e3e1e4b6fd259882ed5a00786f82e8c37ce77d"},
+    {file = "lxml-4.6.2-cp36-cp36m-win32.whl", hash = "sha256:8c88b599e226994ad4db29d93bc149aa1aff3dc3a4355dd5757569ba78632bdf"},
+    {file = "lxml-4.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:6e4183800f16f3679076dfa8abf2db3083919d7e30764a069fb66b2b9eff9939"},
+    {file = "lxml-4.6.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d8d3d4713f0c28bdc6c806a278d998546e8efc3498949e3ace6e117462ac0a5e"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:8246f30ca34dc712ab07e51dc34fea883c00b7ccb0e614651e49da2c49a30711"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:923963e989ffbceaa210ac37afc9b906acebe945d2723e9679b643513837b089"},
+    {file = "lxml-4.6.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:1471cee35eba321827d7d53d104e7b8c593ea3ad376aa2df89533ce8e1b24a01"},
+    {file = "lxml-4.6.2-cp37-cp37m-win32.whl", hash = "sha256:2363c35637d2d9d6f26f60a208819e7eafc4305ce39dc1d5005eccc4593331c2"},
+    {file = "lxml-4.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f4822c0660c3754f1a41a655e37cb4dbbc9be3d35b125a37fab6f82d47674ebc"},
+    {file = "lxml-4.6.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:0448576c148c129594d890265b1a83b9cd76fd1f0a6a04620753d9a6bcfd0a4d"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:60a20bfc3bd234d54d49c388950195d23a5583d4108e1a1d47c9eef8d8c042b3"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2e5cc908fe43fe1aa299e58046ad66981131a66aea3129aac7770c37f590a644"},
+    {file = "lxml-4.6.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:50c348995b47b5a4e330362cf39fc503b4a43b14a91c34c83b955e1805c8e308"},
+    {file = "lxml-4.6.2-cp38-cp38-win32.whl", hash = "sha256:94d55bd03d8671686e3f012577d9caa5421a07286dd351dfef64791cf7c6c505"},
+    {file = "lxml-4.6.2-cp38-cp38-win_amd64.whl", hash = "sha256:7a7669ff50f41225ca5d6ee0a1ec8413f3a0d8aa2b109f86d540887b7ec0d72a"},
+    {file = "lxml-4.6.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e0bfe9bb028974a481410432dbe1b182e8191d5d40382e5b8ff39cdd2e5c5931"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:6fd8d5903c2e53f49e99359b063df27fdf7acb89a52b6a12494208bf61345a03"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7e9eac1e526386df7c70ef253b792a0a12dd86d833b1d329e038c7a235dfceb5"},
+    {file = "lxml-4.6.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:7ee8af0b9f7de635c61cdd5b8534b76c52cd03536f29f51151b377f76e214a1a"},
+    {file = "lxml-4.6.2-cp39-cp39-win32.whl", hash = "sha256:2e6fd1b8acd005bd71e6c94f30c055594bbd0aa02ef51a22bbfa961ab63b2d75"},
+    {file = "lxml-4.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:535332fe9d00c3cd455bd3dd7d4bacab86e2d564bdf7606079160fa6251caacf"},
+    {file = "lxml-4.6.2.tar.gz", hash = "sha256:cd11c7e8d21af997ee8079037fff88f16fda188a9776eb4b81c7e4c9c0a7d7fc"},
 ]
 markupsafe = [
     {file = "MarkupSafe-1.1.1-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:09027a7803a62ca78792ad89403b1b7a73a01c8cb65909cd876f7fcebd79b161"},
@@ -2311,43 +2256,47 @@ mccabe = [
     {file = "mccabe-0.6.1.tar.gz", hash = "sha256:dd8d182285a0fe56bace7f45b5e7d1a6ebcbf524e8f3bd87eb0f125271b8831f"},
 ]
 more-itertools = [
-    {file = "more-itertools-8.5.0.tar.gz", hash = "sha256:6f83822ae94818eae2612063a5101a7311e68ae8002005b5e05f03fd74a86a20"},
-    {file = "more_itertools-8.5.0-py3-none-any.whl", hash = "sha256:9b30f12df9393f0d28af9210ff8efe48d10c94f73e5daf886f10c4b0b0b4f03c"},
+    {file = "more-itertools-8.6.0.tar.gz", hash = "sha256:b3a9005928e5bed54076e6e549c792b306fddfe72b2d1d22dd63d42d5d3899cf"},
+    {file = "more_itertools-8.6.0-py3-none-any.whl", hash = "sha256:8e1a2a43b2f2727425f2b5839587ae37093f19153dc26c0927d1048ff6557330"},
 ]
 multidict = [
-    {file = "multidict-5.0.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:11dcf2366da487d5b9de1d4b2055308c7ed9bde1a52973d07a89b42252af9ebe"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:167bd8e6351b57525bbf2d524ca5a133834699a2fcb090aad0c330c6017f3f3e"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:60af726c19a899ed49bbb276e062f08b80222cb6b9feda44b59a128b5ff52966"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:32f0a904859a6274d7edcbb01752c8ae9c633fb7d1c131771ff5afd32eceee42"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:7561a804093ea4c879e06b5d3d18a64a0bc21004bade3540a4b31342b528d326"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:786ad04ad954afe9927a1b3049aa58722e182160fe2fcac7ad7f35c93595d4f6"},
-    {file = "multidict-5.0.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:02b2ea2bb1277a970d238c5c783023790ca94d386c657aeeb165259950951cc6"},
-    {file = "multidict-5.0.0-cp36-cp36m-win_amd64.whl", hash = "sha256:932964cf57c0e59d1f3fb63ff342440cf8aaa75bf0dbcbad902c084024975380"},
-    {file = "multidict-5.0.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:c692087913e12b801a759e25a626c3d311f416252dfba2ecdfd254583427949f"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cda06c99cd6f4a36571bb38e560a6fcfb1f136521e57f612e0bc31957b1cd4bd"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:84e4943d8725659942e7401bdf31780acde9cfdaf6fe977ff1449fffafcd93a9"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:bbec545b8f82536bc50afa9abce832176ed250aa22bfff3e20b3463fb90b0b35"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:c339b7d73c0ea5c551025617bb8aa1c00a0111187b6545f48836343e6cfbe6a0"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:0ce1d956ecbf112d49915ebc2f29c03e35fe451fb5e9f491edf9a2f4395ee0af"},
-    {file = "multidict-5.0.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:39713fa2c687e0d0e709ad751a8a709ac051fcdc7f2048f6fd09365dd03c83eb"},
-    {file = "multidict-5.0.0-cp37-cp37m-win_amd64.whl", hash = "sha256:0ffdb4b897b15df798c0a5939a0323ccf703f2bae551dfab4eb1af7fbab38ead"},
-    {file = "multidict-5.0.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:4ef76ce695da72e176f6a51867afb3bf300ce16ba2597824caaef625af5906a9"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:711289412b78cf41a21457f4c806890466013d62bf4296bd3d71fad73ff8a581"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2b0cfc33f53e5c8226f7d7c4e126fa0780f970ef1e96f7c6353da7d01eafe490"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:28b5913e5b6fef273e5d4230b61f33c8a51c3ce5f44a88582dee6b5ca5c9977b"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:a5eca9ee72b372199c2b76672145e47d3c829889eefa2037b1f3018f54e5f67d"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:20eaf1c279c543e07c164e4ac02151488829177da06607efa7ccfecd71b21e79"},
-    {file = "multidict-5.0.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:ec8bc0ab00c76c4260a201eaa58812ea8b1b7fde0ecf5f9c9365a182bd4691ed"},
-    {file = "multidict-5.0.0-cp38-cp38-win_amd64.whl", hash = "sha256:aad240c1429e386af38a2d6761032f0bec5177fed7c5f582c835c99fff135b5c"},
-    {file = "multidict-5.0.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:52b5b51281d760197ce3db063c166fdb626e01c8e428a325aa37198ce31c9565"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:5263359a03368985b5296b7a73363d761a269848081879ba04a6e4bfd0cf4a78"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:620c39b1270b68e194023ad471b6a54bdb517bb48515939c9829b56c783504a3"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:2739d1d9237835122b27d88990849ecf41ef670e0fcb876159edd236ca9ef40f"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:62f6e66931fb87e9016e7c1cc806ab4f3e39392fd502362df3cac888078b27cb"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:5dd303b545b62f9d2b14f99fbdb84c109a20e64a57f6a192fe6aebcb6263b59d"},
-    {file = "multidict-5.0.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:60b12d14bc122ba2dae1e4460a891b3a96e73d815b4365675f6ec0a1725416a5"},
-    {file = "multidict-5.0.0-cp39-cp39-win_amd64.whl", hash = "sha256:79dc3e6e7ce853fb7ed17c134e01fcb0d0c826b33201aa2a910fb27ed75c2eb9"},
-    {file = "multidict-5.0.0.tar.gz", hash = "sha256:1b324444299c3a49b601b1bf621fc21704e29066f6ac2b7d7e4034a4a18662a1"},
+    {file = "multidict-5.1.0-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:b7993704f1a4b204e71debe6095150d43b2ee6150fa4f44d6d966ec356a8d61f"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9dd6e9b1a913d096ac95d0399bd737e00f2af1e1594a787e00f7975778c8b2bf"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f21756997ad8ef815d8ef3d34edd98804ab5ea337feedcd62fb52d22bf531281"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab820665e67373de5802acae069a6a05567ae234ddb129f31d290fc3d1aa56d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:9436dc58c123f07b230383083855593550c4d301d2532045a17ccf6eca505f6d"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:830f57206cc96ed0ccf68304141fec9481a096c4d2e2831f311bde1c404401da"},
+    {file = "multidict-5.1.0-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:2e68965192c4ea61fff1b81c14ff712fc7dc15d2bd120602e4a3494ea6584224"},
+    {file = "multidict-5.1.0-cp36-cp36m-win32.whl", hash = "sha256:2f1a132f1c88724674271d636e6b7351477c27722f2ed789f719f9e3545a3d26"},
+    {file = "multidict-5.1.0-cp36-cp36m-win_amd64.whl", hash = "sha256:3a4f32116f8f72ecf2a29dabfb27b23ab7cdc0ba807e8459e59a93a9be9506f6"},
+    {file = "multidict-5.1.0-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:46c73e09ad374a6d876c599f2328161bcd95e280f84d2060cf57991dec5cfe76"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:018132dbd8688c7a69ad89c4a3f39ea2f9f33302ebe567a879da8f4ca73f0d0a"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:4b186eb7d6ae7c06eb4392411189469e6a820da81447f46c0072a41c748ab73f"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3a041b76d13706b7fff23b9fc83117c7b8fe8d5fe9e6be45eee72b9baa75f348"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:051012ccee979b2b06be928a6150d237aec75dd6bf2d1eeeb190baf2b05abc93"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:6a4d5ce640e37b0efcc8441caeea8f43a06addace2335bd11151bc02d2ee31f9"},
+    {file = "multidict-5.1.0-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:5cf3443199b83ed9e955f511b5b241fd3ae004e3cb81c58ec10f4fe47c7dce37"},
+    {file = "multidict-5.1.0-cp37-cp37m-win32.whl", hash = "sha256:f200755768dc19c6f4e2b672421e0ebb3dd54c38d5a4f262b872d8cfcc9e93b5"},
+    {file = "multidict-5.1.0-cp37-cp37m-win_amd64.whl", hash = "sha256:05c20b68e512166fddba59a918773ba002fdd77800cad9f55b59790030bab632"},
+    {file = "multidict-5.1.0-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:54fd1e83a184e19c598d5e70ba508196fd0bbdd676ce159feb412a4a6664f952"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0e3c84e6c67eba89c2dbcee08504ba8644ab4284863452450520dad8f1e89b79"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:dc862056f76443a0db4509116c5cd480fe1b6a2d45512a653f9a855cc0517456"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:0e929169f9c090dae0646a011c8b058e5e5fb391466016b39d21745b48817fd7"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:d81eddcb12d608cc08081fa88d046c78afb1bf8107e6feab5d43503fea74a635"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:585fd452dd7782130d112f7ddf3473ffdd521414674c33876187e101b588738a"},
+    {file = "multidict-5.1.0-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:37e5438e1c78931df5d3c0c78ae049092877e5e9c02dd1ff5abb9cf27a5914ea"},
+    {file = "multidict-5.1.0-cp38-cp38-win32.whl", hash = "sha256:07b42215124aedecc6083f1ce6b7e5ec5b50047afa701f3442054373a6deb656"},
+    {file = "multidict-5.1.0-cp38-cp38-win_amd64.whl", hash = "sha256:929006d3c2d923788ba153ad0de8ed2e5ed39fdbe8e7be21e2f22ed06c6783d3"},
+    {file = "multidict-5.1.0-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b797515be8743b771aa868f83563f789bbd4b236659ba52243b735d80b29ed93"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux1_i686.whl", hash = "sha256:d5c65bdf4484872c4af3150aeebe101ba560dcfb34488d9a8ff8dbcd21079647"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:b47a43177a5e65b771b80db71e7be76c0ba23cc8aa73eeeb089ed5219cdbe27d"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:806068d4f86cb06af37cd65821554f98240a19ce646d3cd24e1c33587f313eb8"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:46dd362c2f045095c920162e9307de5ffd0a1bfbba0a6e990b344366f55a30c1"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:ace010325c787c378afd7f7c1ac66b26313b3344628652eacd149bdd23c68841"},
+    {file = "multidict-5.1.0-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:ecc771ab628ea281517e24fd2c52e8f31c41e66652d07599ad8818abaad38cda"},
+    {file = "multidict-5.1.0-cp39-cp39-win32.whl", hash = "sha256:fc13a9524bc18b6fb6e0dbec3533ba0496bbed167c56d0aabefd965584557d80"},
+    {file = "multidict-5.1.0-cp39-cp39-win_amd64.whl", hash = "sha256:7df80d07818b385f3129180369079bd6934cf70469f99daaebfac89dca288359"},
+    {file = "multidict-5.1.0.tar.gz", hash = "sha256:25b4e5f22d3a37ddf3effc0710ba692cfc792c2b9edfb9c05aefe823256e84d5"},
 ]
 mypy-extensions = [
     {file = "mypy_extensions-0.4.3-py2.py3-none-any.whl", hash = "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d"},
@@ -2365,8 +2314,8 @@ netaddr = [
     {file = "netaddr-0.8.0.tar.gz", hash = "sha256:d6cc57c7a07b1d9d2e917aa8b36ae8ce61c35ba3fcd1b83ca31c5a0ee2b5a243"},
 ]
 netconan = [
-    {file = "netconan-0.11.2-py2.py3-none-any.whl", hash = "sha256:8164c776a32c784b43fe01d03dd2dca71d632617e015613eda8bf7b93040b14a"},
-    {file = "netconan-0.11.2.tar.gz", hash = "sha256:f854e38d3a8f2e72a649bff1f1f6fbfcabda0c758fdc3cab00bbe889b6c8f16e"},
+    {file = "netconan-0.11.3-py2.py3-none-any.whl", hash = "sha256:adee9995cfbe1ed70a1a181a687aaefd7dee221c9d8aeccf0e66dbc4ec3e04db"},
+    {file = "netconan-0.11.3.tar.gz", hash = "sha256:cb050e04cc519324fffd073d7fc24beb839b405d33931a87a37567244b70cc8f"},
 ]
 netmiko = [
     {file = "netmiko-3.3.2-py2.py3-none-any.whl", hash = "sha256:1f8b86432fde2fb3c15ed86e130a05e7da358aa1de23fc7c520d8dbac2d4781a"},
@@ -2381,39 +2330,47 @@ ntc-templates = [
     {file = "ntc_templates-1.6.0.tar.gz", hash = "sha256:a4420beee9cc14797d945b51bffd6e0126913b2dbc672d2e0a1530d3fec5b28d"},
 ]
 numpy = [
-    {file = "numpy-1.19.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:b594f76771bc7fc8a044c5ba303427ee67c17a09b36e1fa32bde82f5c419d17a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e6ddbdc5113628f15de7e4911c02aed74a4ccff531842c583e5032f6e5a179bd"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3733640466733441295b0d6d3dcbf8e1ffa7e897d4d82903169529fd3386919a"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:4339741994c775396e1a274dba3609c69ab0f16056c1077f18979bec2a2c2e6e"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:7c6646314291d8f5ea900a7ea9c4261f834b5b62159ba2abe3836f4fa6705526"},
-    {file = "numpy-1.19.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:7118f0a9f2f617f921ec7d278d981244ba83c85eea197be7c5a4f84af80a9c3c"},
-    {file = "numpy-1.19.2-cp36-cp36m-win32.whl", hash = "sha256:9a3001248b9231ed73894c773142658bab914645261275f675d86c290c37f66d"},
-    {file = "numpy-1.19.2-cp36-cp36m-win_amd64.whl", hash = "sha256:967c92435f0b3ba37a4257c48b8715b76741410467e2bdb1097e8391fccfae15"},
-    {file = "numpy-1.19.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:d526fa58ae4aead839161535d59ea9565863bb0b0bdb3cc63214613fb16aced4"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:eb25c381d168daf351147713f49c626030dcff7a393d5caa62515d415a6071d8"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:62139af94728d22350a571b7c82795b9d59be77fc162414ada6c8b6a10ef5d02"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:0c66da1d202c52051625e55a249da35b31f65a81cb56e4c69af0dfb8fb0125bf"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:2117536e968abb7357d34d754e3733b0d7113d4c9f1d921f21a3d96dec5ff716"},
-    {file = "numpy-1.19.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:54045b198aebf41bf6bf4088012777c1d11703bf74461d70cd350c0af2182e45"},
-    {file = "numpy-1.19.2-cp37-cp37m-win32.whl", hash = "sha256:aba1d5daf1144b956bc87ffb87966791f5e9f3e1f6fab3d7f581db1f5b598f7a"},
-    {file = "numpy-1.19.2-cp37-cp37m-win_amd64.whl", hash = "sha256:addaa551b298052c16885fc70408d3848d4e2e7352de4e7a1e13e691abc734c1"},
-    {file = "numpy-1.19.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:58d66a6b3b55178a1f8a5fe98df26ace76260a70de694d99577ddeab7eaa9a9d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:59f3d687faea7a4f7f93bd9665e5b102f32f3fa28514f15b126f099b7997203d"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cebd4f4e64cfe87f2039e4725781f6326a61f095bc77b3716502bed812b385a9"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:c35a01777f81e7333bcf276b605f39c872e28295441c265cd0c860f4b40148c1"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:d7ac33585e1f09e7345aa902c281bd777fdb792432d27fca857f39b70e5dd31c"},
-    {file = "numpy-1.19.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:04c7d4ebc5ff93d9822075ddb1751ff392a4375e5885299445fcebf877f179d5"},
-    {file = "numpy-1.19.2-cp38-cp38-win32.whl", hash = "sha256:51ee93e1fac3fe08ef54ff1c7f329db64d8a9c5557e6c8e908be9497ac76374b"},
-    {file = "numpy-1.19.2-cp38-cp38-win_amd64.whl", hash = "sha256:1669ec8e42f169ff715a904c9b2105b6640f3f2a4c4c2cb4920ae8b2785dac65"},
-    {file = "numpy-1.19.2-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:0bfd85053d1e9f60234f28f63d4a5147ada7f432943c113a11afcf3e65d9d4c8"},
-    {file = "numpy-1.19.2.zip", hash = "sha256:0d310730e1e793527065ad7dde736197b705d0e4c9999775f212b03c44a8484c"},
+    {file = "numpy-1.19.4-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:e9b30d4bd69498fc0c3fe9db5f62fffbb06b8eb9321f92cc970f2969be5e3949"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:fedbd128668ead37f33917820b704784aff695e0019309ad446a6d0b065b57e4"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:8ece138c3a16db8c1ad38f52eb32be6086cc72f403150a79336eb2045723a1ad"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:64324f64f90a9e4ef732be0928be853eee378fd6a01be21a0a8469c4f2682c83"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:ad6f2ff5b1989a4899bf89800a671d71b1612e5ff40866d1f4d8bcf48d4e5764"},
+    {file = "numpy-1.19.4-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:d6c7bb82883680e168b55b49c70af29b84b84abb161cbac2800e8fcb6f2109b6"},
+    {file = "numpy-1.19.4-cp36-cp36m-win32.whl", hash = "sha256:13d166f77d6dc02c0a73c1101dd87fdf01339febec1030bd810dcd53fff3b0f1"},
+    {file = "numpy-1.19.4-cp36-cp36m-win_amd64.whl", hash = "sha256:448ebb1b3bf64c0267d6b09a7cba26b5ae61b6d2dbabff7c91b660c7eccf2bdb"},
+    {file = "numpy-1.19.4-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:27d3f3b9e3406579a8af3a9f262f5339005dd25e0ecf3cf1559ff8a49ed5cbf2"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:16c1b388cc31a9baa06d91a19366fb99ddbe1c7b205293ed072211ee5bac1ed2"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e5b6ed0f0b42317050c88022349d994fe72bfe35f5908617512cd8c8ef9da2a9"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:18bed2bcb39e3f758296584337966e68d2d5ba6aab7e038688ad53c8f889f757"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:fe45becb4c2f72a0907c1d0246ea6449fe7a9e2293bb0e11c4e9a32bb0930a15"},
+    {file = "numpy-1.19.4-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:6d7593a705d662be5bfe24111af14763016765f43cb6923ed86223f965f52387"},
+    {file = "numpy-1.19.4-cp37-cp37m-win32.whl", hash = "sha256:6ae6c680f3ebf1cf7ad1d7748868b39d9f900836df774c453c11c5440bc15b36"},
+    {file = "numpy-1.19.4-cp37-cp37m-win_amd64.whl", hash = "sha256:9eeb7d1d04b117ac0d38719915ae169aa6b61fca227b0b7d198d43728f0c879c"},
+    {file = "numpy-1.19.4-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:cb1017eec5257e9ac6209ac172058c430e834d5d2bc21961dceeb79d111e5909"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux1_i686.whl", hash = "sha256:edb01671b3caae1ca00881686003d16c2209e07b7ef8b7639f1867852b948f7c"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:f29454410db6ef8126c83bd3c968d143304633d45dc57b51252afbd79d700893"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:ec149b90019852266fec2341ce1db513b843e496d5a8e8cdb5ced1923a92faab"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:1aeef46a13e51931c0b1cf8ae1168b4a55ecd282e6688fdb0a948cc5a1d5afb9"},
+    {file = "numpy-1.19.4-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:08308c38e44cc926bdfce99498b21eec1f848d24c302519e64203a8da99a97db"},
+    {file = "numpy-1.19.4-cp38-cp38-win32.whl", hash = "sha256:5734bdc0342aba9dfc6f04920988140fb41234db42381cf7ccba64169f9fe7ac"},
+    {file = "numpy-1.19.4-cp38-cp38-win_amd64.whl", hash = "sha256:09c12096d843b90eafd01ea1b3307e78ddd47a55855ad402b157b6c4862197ce"},
+    {file = "numpy-1.19.4-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:e452dc66e08a4ce642a961f134814258a082832c78c90351b75c41ad16f79f63"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux1_i686.whl", hash = "sha256:a5d897c14513590a85774180be713f692df6fa8ecf6483e561a6d47309566f37"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:a09f98011236a419ee3f49cedc9ef27d7a1651df07810ae430a6b06576e0b414"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:50e86c076611212ca62e5a59f518edafe0c0730f7d9195fec718da1a5c2bb1fc"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f0d3929fe88ee1c155129ecd82f981b8856c5d97bcb0d5f23e9b4242e79d1de3"},
+    {file = "numpy-1.19.4-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:c42c4b73121caf0ed6cd795512c9c09c52a7287b04d105d112068c1736d7c753"},
+    {file = "numpy-1.19.4-cp39-cp39-win32.whl", hash = "sha256:8cac8790a6b1ddf88640a9267ee67b1aee7a57dfa2d2dd33999d080bc8ee3a0f"},
+    {file = "numpy-1.19.4-cp39-cp39-win_amd64.whl", hash = "sha256:4377e10b874e653fe96985c05feed2225c912e328c8a26541f7fc600fb9c637b"},
+    {file = "numpy-1.19.4-pp36-pypy36_pp73-manylinux2010_x86_64.whl", hash = "sha256:2a2740aa9733d2e5b2dfb33639d98a64c3b0f24765fed86b0fd2aec07f6a0a08"},
+    {file = "numpy-1.19.4.zip", hash = "sha256:141ec3a3300ab89c7f2b0775289954d193cc8edb621ea05f99db9cb181530512"},
 ]
 ordered-set = [
     {file = "ordered-set-4.0.2.tar.gz", hash = "sha256:ba93b2df055bca202116ec44b9bead3df33ea63a7d5827ff8e16738b97f33a95"},
 ]
 packaging = [
-    {file = "packaging-20.4-py2.py3-none-any.whl", hash = "sha256:998416ba6962ae7fbd6596850b80e17859a5753ba17c32284f67bfff33784181"},
-    {file = "packaging-20.4.tar.gz", hash = "sha256:4357f74f47b9c12db93624a82154e9b120fa8293699949152b22065d556079f8"},
+    {file = "packaging-20.7-py2.py3-none-any.whl", hash = "sha256:eb41423378682dadb7166144a4926e443093863024de508ca5c9737d6bc08376"},
+    {file = "packaging-20.7.tar.gz", hash = "sha256:05af3bb85d320377db281cf254ab050e1a7ebcbf5410685a9a407e18a1f81236"},
 ]
 pandas = [
     {file = "pandas-0.25.3-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:df8864824b1fe488cf778c3650ee59c3a0d8f42e53707de167ba6b4f7d35f133"},
@@ -2445,8 +2402,8 @@ passlib = [
     {file = "passlib-1.7.4.tar.gz", hash = "sha256:defd50f72b65c5402ab2c573830a6978e5f202ad0d984793c8dde2c4152ebe04"},
 ]
 pathspec = [
-    {file = "pathspec-0.8.0-py2.py3-none-any.whl", hash = "sha256:7d91249d21749788d07a2d0f94147accd8f845507400749ea19c1ec9054a12b0"},
-    {file = "pathspec-0.8.0.tar.gz", hash = "sha256:da45173eb3a6f2a5a487efba21f050af2b41948be6ab52b6a1e3ff22bb8b7061"},
+    {file = "pathspec-0.8.1-py2.py3-none-any.whl", hash = "sha256:aa0cb481c4041bf52ffa7b0d8fa6cd3e88a2ca4879c533c9153882ee2556790d"},
+    {file = "pathspec-0.8.1.tar.gz", hash = "sha256:86379d6b86d75816baba717e64b1a3a3469deb93bb76d613c9ce79edc5cb68fd"},
 ]
 pbr = [
     {file = "pbr-5.5.1-py2.py3-none-any.whl", hash = "sha256:b236cde0ac9a6aedd5e3c34517b423cd4fd97ef723849da6b0d2231142d89c00"},
@@ -2464,8 +2421,8 @@ ply = [
     {file = "ply-3.11.tar.gz", hash = "sha256:00c7c1aaa88358b9c765b6d3000c6eec0ba42abca5351b095321aef446081da3"},
 ]
 prettytable = [
-    {file = "prettytable-1.0.1-py2.py3-none-any.whl", hash = "sha256:e7e464e8f7ecfd9a74c67f8da35f2a7da3d827235ba0a4737bb6d4b19f4a04bb"},
-    {file = "prettytable-1.0.1.tar.gz", hash = "sha256:6bb7f539903cb031fecb855b615cbcac8cd245ebc6fa51c6e23ab3386db89771"},
+    {file = "prettytable-2.0.0-py3-none-any.whl", hash = "sha256:5dc7fcaca227f48deacd86958ae9d7b8c31a186fcb354bbb066763f20adf3eb9"},
+    {file = "prettytable-2.0.0.tar.gz", hash = "sha256:e37acd91976fe6119172771520e58d1742c8479703489321dc1d9c85e7259922"},
 ]
 psutil = [
     {file = "psutil-5.7.3-cp27-none-win32.whl", hash = "sha256:1cd6a0c9fb35ece2ccf2d1dd733c1e165b342604c67454fd56a4c12e0a106787"},
@@ -2500,200 +2457,200 @@ pyasn1 = [
     {file = "pyasn1-0.4.8.tar.gz", hash = "sha256:aef77c9fb94a3ac588e87841208bdec464471d9871bd5050a287cc9a475cd0ba"},
 ]
 pyats = [
-    {file = "pyats-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:c803a11da48ae0dd758caf7bc7e2a9a4a747c32ed09680ddee5de010a6a3671d"},
-    {file = "pyats-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:96d03a4939052e5a3a05669cb6d1faa4c0fe75e6988d0b13d24c38dfb2a2189c"},
-    {file = "pyats-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:fc0dc5a7a4b78a5a63ee1d45cadfeefbebafe4ef03a0280539043fb547a9cd03"},
-    {file = "pyats-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:83e4f1c16a50743a58ca81cd00744e03a6550f97f9d2944cd1a12304b18fe543"},
-    {file = "pyats-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4abe72c2cceaa3cde8bd7397cfa1d330c1eba38cd909b1e424e90056cc52ecf2"},
-    {file = "pyats-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:33705ecae9fdfdc2c636b3994795e808bbc95eb0fd5bc179da9ff30094488bab"},
-    {file = "pyats-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:80f5161ac3c67102b12b986935da1429c49e9e9d39147adb8d8727ecd211490f"},
-    {file = "pyats-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9d08f4b28afdcab5f936e07a4e3169b5508cada1cc91f76d8b41e91d4fbdea1a"},
-    {file = "pyats-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:817fdc4dbb29215e03f5faf9d3bec955d2a793dab7d1ea05290917d748516499"},
-    {file = "pyats-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:2f17600ac5f5952ffedbad56eb36830a56332e7ee9e5486de50aeaf876e8ec8a"},
-    {file = "pyats-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:df86a312478b266fc991e2d5629e74729badded530a53d1fe08192bad82346fe"},
-    {file = "pyats-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:c2e2a10682992e3356895570eee2f0b819e4e376b478b2b7e49ff337c1902817"},
+    {file = "pyats-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:fce4a88f559fd5b210f032db48ab0cfcc567d55d3dfcbfe09fa4ca4cb81aef4a"},
+    {file = "pyats-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:16a8f67648ff3ca987d1674dff1c3f04731dd218a50e94354dca64c31235d408"},
+    {file = "pyats-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:3b5dba7683afae582c4f197cf602ff71c87d4c5a548121e0a31b92301461e6de"},
+    {file = "pyats-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:69f3878fe846c0337d0e73ba07f28b756714784f047865006cfd380324bb5b3e"},
+    {file = "pyats-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:dd1bdd488b5be283e32b809d0f85ef2839c620d88fb6d052eac02b1bf4938624"},
+    {file = "pyats-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:2bc72c38eb641f8193896e102deeb227f0e3bd34519528737c9a65f551615029"},
+    {file = "pyats-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:d003500d6310e56bdaca39f07697b3463e7eb192a3712e4ca0bcf4994891c880"},
+    {file = "pyats-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ac5a7e2a6e9806632b0612d93e59b328c142956b96e32772a54965d58d7bb646"},
+    {file = "pyats-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:dc96c1e542e35062510710240b93b119c030343fe781d1924f67a9bba259b23a"},
+    {file = "pyats-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:504085dd776b4b4cb07648769b94953b4e9dfdfcd597ec965c2b4248478c0f69"},
+    {file = "pyats-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3d9ac2f23ef1f3616eb680c3caacc0e0efd15dcef954a46a03c9d2406d3d513a"},
+    {file = "pyats-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:cf718ba8f890409eb9f5094efa217e0b4455bf0cd2bfe0220f772b134af6b319"},
 ]
 "pyats.aereport" = [
-    {file = "pyats.aereport-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:0569a8370e47e0b68d0ee8abb16d03bc96ca486830523b8124dd8b1a89a640e8"},
-    {file = "pyats.aereport-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:9ff44351afc7341823070698ea428b7287834ea4433dc023dfa8f51a02fed4bb"},
-    {file = "pyats.aereport-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:c0b592e16c2a29fbff6b4277abfb839fde40c093d084480504283dfb558dc68e"},
-    {file = "pyats.aereport-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:1a18dcf224bbf16aaecd9202e8de5ff7e9a3f91004e67e4756a660578f8f6dfc"},
-    {file = "pyats.aereport-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9c43f79a3e814c8c2cbddffc3cac7001c979a157e86f60128db80e15f33db9e3"},
-    {file = "pyats.aereport-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:db223b82847bca3f4251594c61a74bc7edac9ab56753c579f9c6e61e32bb022a"},
-    {file = "pyats.aereport-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:02ca19f45d44556a841b27a658f3c2165217fa50da0f11e9aa7e20d6855e25db"},
-    {file = "pyats.aereport-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4c67f9f4f92f1f0a70d65566e500366fbe0a9a3dd80b15ad04b788acedfd17b6"},
-    {file = "pyats.aereport-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:60cfffd80ba5933b1388a25d686f8107f30a350e4892fce980bae8c801d20a52"},
-    {file = "pyats.aereport-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:ce5dd15b5394309b821c93fa22ba0f6b1c4498b604fd56c970ab0d86164ce5e7"},
-    {file = "pyats.aereport-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:504a03da3709bb47aff661fa2a1cf6866e734eaa7fdf54b84176ae46baa35b42"},
-    {file = "pyats.aereport-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ec57b04fe57bb88cb5647e153d354592a4586051ed0ba0df2c116d7c5995df0c"},
+    {file = "pyats.aereport-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:23ccce3c0c2de3fad2510f42e0a1b2a67f1d0a38f74c860bca4cad99ce4d5d5a"},
+    {file = "pyats.aereport-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:ce4a35ed4a294c83cd836b920ba10f0a7e39725b8ecd817e602d40390ac6be05"},
+    {file = "pyats.aereport-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:aaa8d7589711eebcd1ac779dd538466c4a174838d6660d1d35653c0033362c36"},
+    {file = "pyats.aereport-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:27709b2125d7705b803589ded18238e3679fcbacbe2ed814240024032baec3b2"},
+    {file = "pyats.aereport-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:eb09e651d70c73338426914307f163a4d255e7e4902df29cfa1a250e738fc858"},
+    {file = "pyats.aereport-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ef8e2d56b365075a78ced4bed27dad643ff86f15470e78b2b97600114ccca226"},
+    {file = "pyats.aereport-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:424af200d5c8a9581607bb6b55b6a9c004539ed5bd55783cefa45c6b34c33391"},
+    {file = "pyats.aereport-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a2ee5f59f9277e0ebc363185c7d0b358be6ebe46baf1fd82b4d615e026f3b6f1"},
+    {file = "pyats.aereport-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:892822018703d300060a4e7d8a3bea99004b111c9f790f669afeae9bad970231"},
+    {file = "pyats.aereport-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:6562667e10eab2c71b67a0f6f8d02cc5447570a509c85ac9a2f299659d49b145"},
+    {file = "pyats.aereport-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7cd7e3f5ab37037372997aca7c5dd9a92310286b325a52b5142472979982b65f"},
+    {file = "pyats.aereport-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:39ceca794d555637809fa7e44af3917073527acec379179a647dec8f5a5785c0"},
 ]
 "pyats.aetest" = [
-    {file = "pyats.aetest-20.9.2-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:06dfa3fa2f4c67cb1376b163a4fc99ecea14a28b03614a8fa71b3f3d83b9e04e"},
-    {file = "pyats.aetest-20.9.2-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:6158e2699614d8f429861e28e726e76f6f277bb244b9558c03b8f69d1cb6b55a"},
-    {file = "pyats.aetest-20.9.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:bde75fd1f5adfb74e34d14d0601312b31851115289a5c77dbde47a8c74c40941"},
-    {file = "pyats.aetest-20.9.2-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:5f3f074e68003bf39705ef2c13c042bf88898467cea4ace704b45de1f322fc51"},
-    {file = "pyats.aetest-20.9.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:cab413855b857e878edb24307b526e2abe1e4aac545f374348650c2dafbcb0ce"},
-    {file = "pyats.aetest-20.9.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:de24774b64329589a7746714cd8bcaa800140c8fe26d0b8bd8d11fe42e872862"},
-    {file = "pyats.aetest-20.9.2-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:bbff590dd469a471ead8e3e74a16d4baaf43de2e62fc3a551500aa984ed08c85"},
-    {file = "pyats.aetest-20.9.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e7a8c807b3a9e038865222a6565cd134f4dfdafe541d7ff76c903a78cd1305a6"},
-    {file = "pyats.aetest-20.9.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:eaf3ceaa8878216cccd95ee01259b2d84f978dd140eaef75184aee1259df6128"},
-    {file = "pyats.aetest-20.9.2-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:e2fe743147fdf6a6ba6744412cd559917f5297e0b858f693c972265188bc4d7e"},
-    {file = "pyats.aetest-20.9.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:af2b8af05cea185ec249b9684d63a0ebac180bfae80b0173d374325287b9e54b"},
-    {file = "pyats.aetest-20.9.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:069d4a550809566ad428e2f11e55e8a5a023be8fb3521d667726ed802f9647eb"},
+    {file = "pyats.aetest-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:631b89a554ce00a0f341a5090bac37ddfb4a9abadb1e9096d69ab2d4bbaf074f"},
+    {file = "pyats.aetest-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73dd6928975641732ed5d38b836def4c3becb2aae297c28d243be7d32d518ebe"},
+    {file = "pyats.aetest-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7ced376ad8099eccf6ac838ead60387949bc89f176db6b0c9faef464313ec977"},
+    {file = "pyats.aetest-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:490343daca1fee6fb893bc117ff31f2a9ce30b63b31e14b9b233bcdd867a7604"},
+    {file = "pyats.aetest-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:7691e5d6c1ab5bc661d696cae92d6d3564fc1e44addc81d555ff0e1389d2f96e"},
+    {file = "pyats.aetest-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:04d3bf1e2d0aa28c1f894751d0c2f551bfd9a6aa865867dd5c4817d92bd2b8d8"},
+    {file = "pyats.aetest-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:708d8f220cadb55a246eef2c363a7c5e2419de52c0c78302dbe8eff2e6da7c8e"},
+    {file = "pyats.aetest-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:cdfd934eb4281de5fa5affcefc8aa359a8ae0847d22570af4f13996d407bf03f"},
+    {file = "pyats.aetest-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:369b1c403ec66b8753369ea723f49143b96d499da531365f2ba50da4d59639dd"},
+    {file = "pyats.aetest-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:c28902c9c32b218d8067ba289263fe49272b37a6f34a8b6d9654714b3dd95b7d"},
+    {file = "pyats.aetest-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0d19c9507fa29dc33a7e9641429bbbed7a5bd892c6de5ed269909a9072637953"},
+    {file = "pyats.aetest-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:9027842b21bf867482b6990d791e9351c34c22eb2a90f111eecdc7c73afc75de"},
 ]
 "pyats.async" = [
-    {file = "pyats.async-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:f29bf426dec6ec1ae636646774e2d49a20cf05a600a4f10a85655eec4abeb427"},
-    {file = "pyats.async-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:f1da812de8c2b3f4451077e3e93bde15f6dc0380280d4860f193326a66dddecc"},
-    {file = "pyats.async-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f6d50c0f09cb359677eb5f1039bfd2024ac5e10c12d66a0b86d04e85bcd6fcb6"},
-    {file = "pyats.async-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:449f30ec0d35a51957014b064b45506b8cf9e0748e7145ec5a2ede4d2cf5405f"},
-    {file = "pyats.async-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c5f379d2a717516f08e69158e50cd192e398467b996758396cff671a858215b9"},
-    {file = "pyats.async-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a562cc52c3a775000c0ccd12d3084af5b373d57577a6960405a8cc16865befa8"},
-    {file = "pyats.async-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:d2d00817202c5ad28a7279f1d0fba70bab0afc52ee9e076c2431a6e2aad7e352"},
-    {file = "pyats.async-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:d24ef63c218d81a362a7ff2b8a1e92a38c858ba4424b9d9f6ad1239ca9e631d7"},
-    {file = "pyats.async-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:1317d018bd0e1bdffefab30d08fa0e1779f8e1e4a78193e51d36114c7f4a3c06"},
-    {file = "pyats.async-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:0b3043e4abdc25cdd77c3cfcbfa659b26830f32533d3fa12603e255d16094800"},
-    {file = "pyats.async-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:68a747378bf6fc2d5c2d63e43425e08afce661317d912556e2ead669c8a73b2d"},
-    {file = "pyats.async-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:b862b1885287e88e3982b36f1d1279eabb429030055a24961b4b44c3c3c3d3c9"},
+    {file = "pyats.async-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:fa59bdfe5e16d359b3d502beae313b4e097510535756bbdab67b01cf6a14160f"},
+    {file = "pyats.async-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:aaaed97d1b5c9fd5f94c4dbaa6d48409ae5978c5cab13c4cad8234710478d33b"},
+    {file = "pyats.async-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:4f6b6a8b55463babcc984d11d8b7b004c107f9a820b36905b567352e8818c36f"},
+    {file = "pyats.async-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:31fbd14e43aed368684665e87b50b7945c4fd1c0af172effbb7ab520f8542979"},
+    {file = "pyats.async-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b97b716436ce46edf0cc4c6702bc1133e1e50a4cdce63ebb6d0ad5a69a883cb7"},
+    {file = "pyats.async-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:dac6ffa545ac18b1a631b3cd25bd6742b1b1865067c0b1ece1477c852468236c"},
+    {file = "pyats.async-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:b036ec3fff2e61333359859182f749169faf643f42a620dcd815cc99e7585783"},
+    {file = "pyats.async-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:7a74b88743e77a14b1c44f8d5041ef3f6fc650668a2a88ac5a07d05e7ec10814"},
+    {file = "pyats.async-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:69fe00cd23727d4454995866de7f548e22c73c33898698da5d393cb70971f20a"},
+    {file = "pyats.async-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:7afc2097e4df6788a984801e50f5ea8d757edfde211e1aeca1d646772266a9d7"},
+    {file = "pyats.async-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:2c44de280606e72ed1e1c6253c29d3e65335b7d3f89f5c9f9beab19867df63bf"},
+    {file = "pyats.async-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fdcb62005745fc6db03326e8568e72e598455059867688faa7a7a08a15cb4cc3"},
 ]
 "pyats.connections" = [
-    {file = "pyats.connections-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:3e2185f25e3e08caad8ef276b0dbd2e202e83580b86f49dba9c3f782eb00abdc"},
-    {file = "pyats.connections-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:1ee131dfc186c3f7b7bf554c0bf57211c37240e25c81f61ebb297a833bf47fed"},
-    {file = "pyats.connections-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:5770cf9628960fcdb6831c1d4a591ed4ba5a247520d15a9127793ebe48e03e91"},
-    {file = "pyats.connections-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:c78c15a0ebb269c6fe4b28633c5ee3b6493b5a1c792d9012f53365131ac7f360"},
-    {file = "pyats.connections-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ba00db32214cc2cd8c5f12ef69c5d78fda88e55e2062add7051df25ec0f43cf6"},
-    {file = "pyats.connections-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:31c5ead46b147dc9b961756534f4a9d22a2d2e01df1b661f68d45e53003ff07d"},
-    {file = "pyats.connections-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:9b2173e768361c6b6ede393a17d1e14453e84422515e9b1664b16497c8232b28"},
-    {file = "pyats.connections-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:093f2534058c4315279e16d84971026350d8b1a6ba753730fc1875da40153178"},
-    {file = "pyats.connections-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a91db671ad9f0d2e5fd3c5a057109e95f01bf6222d1a2003799d92e170baa982"},
-    {file = "pyats.connections-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:bf91a8b7cc308d52c3c0984537416836f79e96efffebcd192b18058002367964"},
-    {file = "pyats.connections-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b0b24ebb92f85e3e7e232824674d8a2d5883ca2d3696d659b34b2dab53795402"},
-    {file = "pyats.connections-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:261cd8b2d1bfbeb97eed935323244e0c8e5255ef8a4d3be5ab5ff9009073b153"},
+    {file = "pyats.connections-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:6a3d1045ae0dde8427377facc28a03e5a7d8c85f97c039467db9a9729c4b0898"},
+    {file = "pyats.connections-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3434fdfe713d47ea4a0be81bc60798e9ac71672f87b2c4ff95b62da56e5c90c7"},
+    {file = "pyats.connections-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:5f200e4a45dfe559f5746d4070ec376fdf089fd803ea8065cedc08f6b1fa18b2"},
+    {file = "pyats.connections-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:b5ae8025cc7efb1ef740647e8fdd74a36a2bfea1df52f959fb0b4965490d9822"},
+    {file = "pyats.connections-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e1a9e49406fe629013dbff328c5db6878275ab160e91892ca43f0ce5b572a418"},
+    {file = "pyats.connections-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f99a2a90d5c1e387229f83622f6bf5ae0798bc0d95ad6b283926fd325bbdaa35"},
+    {file = "pyats.connections-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:6c6e1a2d93f6372856901026e6d2a1cadeeb67052ac69de4512255b138c7a622"},
+    {file = "pyats.connections-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:191debc91ef04b531a260f046281a1a32cf96aabee77ad2af0949080e0c97bca"},
+    {file = "pyats.connections-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5ffdbefdaadb8068e0bf3748b24e54aae7b5c21cd94e9f0fcac295100332cc9a"},
+    {file = "pyats.connections-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:8cad03011cb8f930e788447a95416b3d76779d019e97953707adf09e2b8133b6"},
+    {file = "pyats.connections-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:dbe2889c90c3f64543c15fc59348107a149dc371a3caeee65d5ba9034e0311bd"},
+    {file = "pyats.connections-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:0862abe18219637119058e63c2e3c80482db10f8446172928bfd3cb38ad5307d"},
 ]
 "pyats.datastructures" = [
-    {file = "pyats.datastructures-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:ae4c3a0b5ee6edd3ab24047ae7a88828ce2322e369d365afb14bb71e1eb940ab"},
-    {file = "pyats.datastructures-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:6d44ed0178d4c34b48e0b78d458309772e6c66fd6bdb570705cc94153d022916"},
-    {file = "pyats.datastructures-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f90dc73c7d19ecde5d5b98adf4bc7ec8ee57debe0f596897259054c283bc042e"},
-    {file = "pyats.datastructures-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:ad260b022dc3825920d32c427fcc2ae2f61827b003f07aa1f2de3fd822b20d35"},
-    {file = "pyats.datastructures-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:4053c71d7c105d876d1da70843643b84ebd483326cb56683a80308efc059341a"},
-    {file = "pyats.datastructures-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:7920c6140f6bb2ae1d5b324f32eae8f61861310329b2468385d73382458ff306"},
-    {file = "pyats.datastructures-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:6f807975585790ed17dca5a4cc72e9200851ac99012e0c60ff3cc340001b9028"},
-    {file = "pyats.datastructures-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:960ab0523917bd7cdb96d558db87c73d907ff0d3a28839aef0e3d46b77973c8a"},
-    {file = "pyats.datastructures-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:2fe7e76b696111a3b86f158c812dde6daab2e1ce591d21e478f6d42c775451f6"},
-    {file = "pyats.datastructures-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:c5b45874b4ba2d89436e26bdb203dd55b593f77cbcac819270c4f57093264702"},
-    {file = "pyats.datastructures-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4af50ea141ffeac7d93dd6bb5e0d33cd49ebb56b37666ed4cc60d18ffc110ce0"},
-    {file = "pyats.datastructures-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5441f419a1916bffcc8e39d89d81aae6be20090914c2fa1b87b8ba8c445d707c"},
+    {file = "pyats.datastructures-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:17aae842b2ed02c70e13d8a069a0309ae0c493f28725ea595f2b0e0cd63529ef"},
+    {file = "pyats.datastructures-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:60d2458220c147f51f3beac971c89d29f4b7cb9d4c7e1e81058b3d80ab12589f"},
+    {file = "pyats.datastructures-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:d36cd92cdb8fd93858e1ee2cee99d773f906634d22bf1310ee4a4a1ee5cc0a29"},
+    {file = "pyats.datastructures-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:cccc214ceb47a89b999066381bb303604a8eb4a99c1f0792a21b17711d2fdfc2"},
+    {file = "pyats.datastructures-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9b0b6b79fc90d6ca688e8a82dc6f5481a9488b7e24e4e5f54f1e5d9bfb807dbd"},
+    {file = "pyats.datastructures-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:1e4f7cd1b81d9830e1894bd076a12ba6db752778a8a66c04e6956264734f1cef"},
+    {file = "pyats.datastructures-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:c134c8084a8844f22bf54871d231660ebe395dce08cdf6d09e6e7bd8b928d336"},
+    {file = "pyats.datastructures-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:9fb8fcfae5061cae149cf4fd778c2071d2146db838aba5e43f9e98d734c5edc5"},
+    {file = "pyats.datastructures-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:059f88fbb4be12254d0fe6b923943dcd0e2b4b947cd30967a4abb681399d1448"},
+    {file = "pyats.datastructures-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:70afb3b8730f1eeca0f2c6132c9fbc6949044486a96afa14acae991cf5478cd7"},
+    {file = "pyats.datastructures-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:66e1143aaabc2eb4f7deaf8c576db5d629ea5a1081bf013d12c1d95fdb6ef6e4"},
+    {file = "pyats.datastructures-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5b9fab361e7d591bfc174122afa7160df62ad606664f15042005fb8521193630"},
 ]
 "pyats.easypy" = [
-    {file = "pyats.easypy-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:2a1cdee3bcb0462be3b65b5ed7282505582a35b66a3b4cac86edf02de502201b"},
-    {file = "pyats.easypy-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:b4f23b3402570137aacba7f0f52b81d32d5cff69d6deb0fec50fa8a515003e68"},
-    {file = "pyats.easypy-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:f3f7f41d08527af1081358abbb67bc40ab8c13cc73854e0989a2ac25305cca12"},
-    {file = "pyats.easypy-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:efea2ab11701152e421927464927643b04ba32d24c37e82f02be31af058582d1"},
-    {file = "pyats.easypy-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:0d791b1601814e4d02bc7ab470ea6a8e4ebcdd8511a733d5f440b01b46842241"},
-    {file = "pyats.easypy-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a4fe8f520a4b0eaed3ebf9cbd0b63050652e7bcacea412785b3e20c64e000306"},
-    {file = "pyats.easypy-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:7914af725d6fb5de925424b2c394462e46a818f677a83badd0dc6bf4dda035a5"},
-    {file = "pyats.easypy-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:49ad81d8e4a43ab718ca235f9f7081d911803d2dde24b7c7035c840e55cf7c95"},
-    {file = "pyats.easypy-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:bf5b56938393b502082bced081c278729c0a888f1e1c1e45424cfe418e58e443"},
-    {file = "pyats.easypy-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:356f77c8b75a9a2d89bbdbb2b5b5867642d93958de6b84ec78d21565397a286a"},
-    {file = "pyats.easypy-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3b032afe767832e35488183e93dd8723adff7d3246587f62baf7433faa7415db"},
-    {file = "pyats.easypy-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:834d3e68314457e51932d388f7e5ca43027ea5c3a2bf67460d9cc2a3ce956540"},
+    {file = "pyats.easypy-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:1494d9baf19094588baa4a2a747093fa86b1ee6b436f656dca5696013f7b5248"},
+    {file = "pyats.easypy-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4d0e5a6898d5f187ab44fe6b528e1f7380ea0136c2eb5701766abf1bdaf51aa0"},
+    {file = "pyats.easypy-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:dc04c162495335f25e416aeca1fe0161f07552cb1beaea372e532b681ac89299"},
+    {file = "pyats.easypy-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:ab79a2b2c0f63cd9fae1e05f0666eaeef4823579b042eafacb8a50c9a6ff620b"},
+    {file = "pyats.easypy-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:b2e6a6f954ed4e394b0ca0c5b2d241da5773b2c1162ef8bb1eccb816edb8d3fe"},
+    {file = "pyats.easypy-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3a609bdebed5f14ab9747ac430ed678f9a9a0f71f095d883ee096eac71f3a232"},
+    {file = "pyats.easypy-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:430d428c3c41634a6b966b07fe107b4e6850ad3b7b885bd16077686431465e2a"},
+    {file = "pyats.easypy-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:93dee42261ef4459353c5b0410980f91f5e4c1601651201bd9ae9eaa702d8223"},
+    {file = "pyats.easypy-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:14e2cbcf119313ca02791acd7b962bdf3fdf0d99dc052f0a5286412d81237e98"},
+    {file = "pyats.easypy-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:076fc835a6abeba382e2a91e09ff345ff21fe88caa178b0a78daa3f07b0ba800"},
+    {file = "pyats.easypy-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:ed61249e41dc3a9b77681a15764684ece69a33d1c70d4903ce87913e287a41b6"},
+    {file = "pyats.easypy-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:071a220ddceb6346883d2cf79ed691b8e2e0004a9a8865ef4bb2c1fcd53ac311"},
 ]
 "pyats.kleenex" = [
-    {file = "pyats.kleenex-20.9.1-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:518cfc48bb7bb2ef075ec69bbfca8bd1f4611a200593e14eefe229988b187add"},
-    {file = "pyats.kleenex-20.9.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:f2da92588ae729a55589018a747a9a5c9436e01c12756f9afbfa71eea8f0b2c1"},
-    {file = "pyats.kleenex-20.9.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:12a406479c010947fea785ac63eec82691cda99567eae3b2da22acbe2cab7087"},
-    {file = "pyats.kleenex-20.9.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:52d705f4d39592b900505753830ae42133d74ddaa34c1122f0a25014a9695ac4"},
-    {file = "pyats.kleenex-20.9.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:cd9b6222486dcf2a3de2e43d5ab65cee983805e4c637735c59322f61514f958d"},
-    {file = "pyats.kleenex-20.9.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:97037affaa469a28ab42e6044c1f0d37e87e9f77649b2c2fccdd78fcc6efed57"},
-    {file = "pyats.kleenex-20.9.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:487f51d13e221f873d6d7b2ae85af77c82f67b1d06882a6871249c63ae018e87"},
-    {file = "pyats.kleenex-20.9.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:75b901175db8b69eb926aca92fd841749399f6227612939ee1189b8a45f60c2c"},
-    {file = "pyats.kleenex-20.9.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:fb7b5e936c8a40cb84f7f7c2915fd6507c9fbd098ca50e65785a8054d552e628"},
-    {file = "pyats.kleenex-20.9.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:6b8da4c7f7aa576a4e5f2bb834ef1bd55c6bb98477cc7213a0474e536bec30f3"},
-    {file = "pyats.kleenex-20.9.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4b1be26da715470338cd4e6cc15e085328066143af0f160d297c158252862563"},
-    {file = "pyats.kleenex-20.9.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:324916314c66f0e052d2069df57ac29cc3c4b78064e0247cf54f14635924e700"},
+    {file = "pyats.kleenex-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:da11379cf71c7d3cb6b97168a6df16e04940688ce495f8bdb17f197b2f78d435"},
+    {file = "pyats.kleenex-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:ca1ce9cb909c1d60c82cbedfae18b045da753deb4292608de72f6340a10da235"},
+    {file = "pyats.kleenex-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e283b8726c6cb833c32ca6b49885416fa914f37d3158f2c6fa1092521339de1b"},
+    {file = "pyats.kleenex-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:82cd59d4ab12f14d889576658a027df13962f2aab2b194aa6f3247e601a321be"},
+    {file = "pyats.kleenex-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:5676830e416e589a67de8d62b91c39cad46217c1b26c6bfe2136d82781c76b8d"},
+    {file = "pyats.kleenex-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3d3a01acf6d401249ddfc41f6200e88d48459b09fe97dd0a300ec7f3fc595ebd"},
+    {file = "pyats.kleenex-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:4f0da91dd595094f0b8cdfc8ee9d5b1a2b16e4bdf483ee1f07c69039e96c9271"},
+    {file = "pyats.kleenex-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:44ac343acd8d28792c22f8418df2e31a627ffa922b266c7ab67821d87a7913a7"},
+    {file = "pyats.kleenex-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:e0657fb90c6643ea7a7f0d07a73aebe6b7664c91eecd4759a8a9baa9ae573706"},
+    {file = "pyats.kleenex-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:97ffd2fb3bbe37271db7563cc618dbb5f3115c347bae51b1b1e8916bfb8b0f36"},
+    {file = "pyats.kleenex-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:7ddb3d600c7ddb56e9e250e168840590d1127998422d41546e161fb1e580a4ae"},
+    {file = "pyats.kleenex-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:a32a46609c1afbb084c09449ca3e0a9734b4f59aecb7495a58b269189168470d"},
 ]
 "pyats.log" = [
-    {file = "pyats.log-20.9.1-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:8b0a74ddc7db0d0cbc05b87ff6f7bbb11d0fc6281548e90e9cb348b8eb6b56d7"},
-    {file = "pyats.log-20.9.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:bdad7e4f9abfae66debd9645feec91b0e3c86ea124028b69bfaee65a67316496"},
-    {file = "pyats.log-20.9.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:50127c22db6af5b71fa10c71a290d66f290180ea5c935a2bbef585fed4bd614a"},
-    {file = "pyats.log-20.9.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:fc85d112f6300a7cd142e4c0812c528827f9d5d8a71ace5f92c749c67cdaf1bc"},
-    {file = "pyats.log-20.9.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:24ac1ffd7c856c7e94cdbe8ef7586254e73f8b9aafc0171e223f22bed7fd6da4"},
-    {file = "pyats.log-20.9.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:14f5bd4c7d855d58a5a81b0c717e628c6d859f2d2ca0f666ccfdef61a748e6d4"},
-    {file = "pyats.log-20.9.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:0c2ad23a167abe48532267161cee8b6d5ca1835079db974213b99822459b61c9"},
-    {file = "pyats.log-20.9.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:240755b3ebbfbd0f619df7cd542c92fb6b78cdde386b899770c126ddfb1e19fb"},
-    {file = "pyats.log-20.9.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:643f079d6fd8038192609ef80009f91e5dc7f3c38f3f66b0876336fe01a6d50d"},
-    {file = "pyats.log-20.9.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:a528671d0c2f9c4a08df4155667d5e2a9f2bf2ffa1e0ee0f4706648234f4eb27"},
-    {file = "pyats.log-20.9.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:6ab9de2d4ef67f3b4118afcba70f4cd40391badbe2af37b7a105ce763b107363"},
-    {file = "pyats.log-20.9.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:1b3eb31d19216c385718643e500f1787eb6915a0bfba8d294253d86756d85b9e"},
+    {file = "pyats.log-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:5ed421b9e96aa59c81b7b69139a932ff32393d1ac1d62f1605ac54983f2c54b5"},
+    {file = "pyats.log-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:fa45373f71ee32f070ea11243971f7b9acff66b131f4428983347c3a43d94d48"},
+    {file = "pyats.log-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7cf6355ab56720fa2659651e9de02c3f03e8b34878ba7db18ee39e23a23a6bdb"},
+    {file = "pyats.log-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:fa25c7edcf2d72e33b5dfc2ebc19c2507287fc30199b7887f049fc3301aec785"},
+    {file = "pyats.log-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:44b8123eea2ecee8beffce0d498f90500cdc86f5f056938c53b072a1b12dbc80"},
+    {file = "pyats.log-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:e8ef219e60f159d5c5454258a2fd05b5276e6dd515fe8fbff799460a42d51f98"},
+    {file = "pyats.log-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:c27211b60a1d894a530644e7d177daee39572f70b26a2cf5dd38fdd7f8167663"},
+    {file = "pyats.log-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:c9e683a560b199ddd41f68396e4633b54f972fe8af5064c0f22874d473a0a0b5"},
+    {file = "pyats.log-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e1871375e7033ac79070b1e394279be58b54bab7c82235a0927b705f4a2f959"},
+    {file = "pyats.log-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:b5271a6dfb42576934772c3092d57409b07a603c59ace62b613843f1301d05cd"},
+    {file = "pyats.log-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5dd9d8ee8a36582ff125609afe25c218a367c846bd03f06073ef36f47f26a65a"},
+    {file = "pyats.log-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:7aa38fe23862e9065b2bdcea717b7250747fc86a3c1c5969057b569c71f8aa05"},
 ]
 "pyats.reporter" = [
-    {file = "pyats.reporter-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:68dfcdd8c7abe53adab4ab518b404af4d85fd99c99136fe4a62b47b66548785f"},
-    {file = "pyats.reporter-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:4f06ab47d158974b6f5c3b1a2d3690b1f51ac64a4f3e84c4c47f59269d18ed1f"},
-    {file = "pyats.reporter-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:0965079a996a4aeb19c24c5bf6e13c2bd4d6481c21dbdb68e6dd0616baa954ac"},
-    {file = "pyats.reporter-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:256cd1f12e8e64eeacfcf803ca08a6b86688177c51c3a83797ef63766c899526"},
-    {file = "pyats.reporter-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:dfdd951f7c71d05e04671ba1e224a531b3b1068ab99079d67e059ee8d47c8542"},
-    {file = "pyats.reporter-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:5dc478ad93b74558c53ab5481fca4cf293d208b9aff0487508941a3be9247427"},
-    {file = "pyats.reporter-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:616bdb3126e17963f6d427573b1fbfb13c1a133b7c14932102ce2f36a4697a97"},
-    {file = "pyats.reporter-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:0751d269e20c18fc3c06f9e217c5dc2563d2a0c77bdf8941526d20f3e3097117"},
-    {file = "pyats.reporter-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5a82fa39419fc8ed4b99f3d1a1c5dc3bec58a7bff58010fa61eee2fa59ad3aa4"},
-    {file = "pyats.reporter-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:d42b405af71d7a7110aa9cc5fb7d5d66ae7874857129b9ee3f6d280aea3c8954"},
-    {file = "pyats.reporter-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d0ae6b7a1979818b010fbc70eedd6233f8c3059823dfb17c56ffca5c58f4c0ad"},
-    {file = "pyats.reporter-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:10be0466fa57c25d9b1f8bdebb317b21e58ebd92626f5af9c73e38205397b7c7"},
+    {file = "pyats.reporter-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:f48be389b8208407a09570d6cab7659543e4e93166432c3ff2cdff069fd57a47"},
+    {file = "pyats.reporter-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:79e7c047ef1e27002763e0cb747e7e7a7d00b9be9412d1433d1c87f151239376"},
+    {file = "pyats.reporter-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:33a46e7743ca8fd7dae117972808cd73bc53073c2ceda1754685f97af6c6de41"},
+    {file = "pyats.reporter-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:dc1c175ffc1909fdb195518b36647c3c2ee194dc9d095564c1920423046a911c"},
+    {file = "pyats.reporter-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:64c0944fd8a4da4d582c9a14f26e3064dabf6a79e172fc8d36e4d238f274ca17"},
+    {file = "pyats.reporter-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6fe7eac2aaccba190022cd988b9b23f7c70cbf4fb93e5ebc8412f9aef90ec37f"},
+    {file = "pyats.reporter-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:04bf18876398ccfcda31340c06ee9987103094f584ab6ad20fc70fdda0919c1f"},
+    {file = "pyats.reporter-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:534a5f875609f676513dffd9eb313bfc873550057d47079758170a432784e782"},
+    {file = "pyats.reporter-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:60a519461ac42eb6c30a54ca51b3e1d4c193d5f3d96dd6a5e738a37b6942ea5c"},
+    {file = "pyats.reporter-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:14117a1a8a031e7875933bdc0f214c9555a87ee0135b716b444de1369322d869"},
+    {file = "pyats.reporter-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4d58137fcc5bb47c2320f1c1d133d8f8bb28b08fa9798afa148e1d304d201c59"},
+    {file = "pyats.reporter-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:fe21b7544b3c94e8c51ced5edf0c397a08b6f8360588eba552c4a1738cba871e"},
 ]
 "pyats.results" = [
-    {file = "pyats.results-20.9.1-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:1824ffd481574bdfb440ac83ff07fddccd6660244b52f4d7192cd65f8ecdc095"},
-    {file = "pyats.results-20.9.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:3546a5a4685b2604e2274f20000a4178af5471acab4ef4749b42e14e55e8903b"},
-    {file = "pyats.results-20.9.1-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:901c50f797fb23610c47b6088ecf02e4dff03f96b4fead9c1af12cdd5a31e722"},
-    {file = "pyats.results-20.9.1-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:7b4dd1415f08132f49a5d32a4a856f972bfb09318a4072012de3462e5836e9c5"},
-    {file = "pyats.results-20.9.1-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:ae40ed280c158cca472eba4928ac1795d7d87aa8f82a3d06dfd36e221464a5e6"},
-    {file = "pyats.results-20.9.1-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:3a83db24a8751099cc1a6a5569ee29fc0c66d70f76a26c6f41fe5cd350f19014"},
-    {file = "pyats.results-20.9.1-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:73092ae18a2d43b52e715f7cbd27caa845580d78da5f50dfe63de9d88d8d0c3b"},
-    {file = "pyats.results-20.9.1-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:97da13f1129c323d4da1e0e5320c899cb224ecef6fd5a6341af3ee024b663209"},
-    {file = "pyats.results-20.9.1-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7d1aeffa22d30b6e17edf0966fad50e1b2df5073278bcb2454b14ba0fec4a9f5"},
-    {file = "pyats.results-20.9.1-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:0a411a0f63401514e4af579063c93fc9ef46e910fb5a49485e3af6da5d28f0f5"},
-    {file = "pyats.results-20.9.1-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b466d93ae00991a3bbd11d819905eb20e7e399d9096992c1c816191e7494faba"},
-    {file = "pyats.results-20.9.1-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:986bdf5c6afcdbdb03709fb784fb2fd26016267df104465aa42a0d60aeedaf9c"},
+    {file = "pyats.results-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:c36165749f51344f1e38a4e6cbc7021a67bde13266f0de78c8e206bacf892644"},
+    {file = "pyats.results-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:d312ac9e226ec9f31e37269e268edc93c395c5996061ece1bf9983534773ae25"},
+    {file = "pyats.results-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:30e5ba78e3c0d3033bce30b80125dd5dbbfe70b23e61bbe2bb0c7d62ed9b424c"},
+    {file = "pyats.results-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:05ca31e5cee06872d950b74c9bea05a624f8b9f89f52a87eb1d85e98f7235425"},
+    {file = "pyats.results-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d064dcacc8eb9cfebc0299f24a8a2adb7268d50456701fa136d84ab7a2aa8d1f"},
+    {file = "pyats.results-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a1858384ba02bbf76b31d289a0b60932f47ca1a2454f4f8aaf7c02af982e019f"},
+    {file = "pyats.results-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:e9059848d0bd903555f5948b384a140dcd24fb689eafa3dae67578f91d8e6bf4"},
+    {file = "pyats.results-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:ede9952cc4f8666d5a720671e53a834f68a52cbab2d69a56df913a5cdf85e1d0"},
+    {file = "pyats.results-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:4e00150b877e298faa54016381cfddffd3295af18a8b8a3b08b43be1773658d1"},
+    {file = "pyats.results-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:95dfab9b357d42eebd62d5216f8443b74f00ce6f8ca53ed71ce00f230caa05eb"},
+    {file = "pyats.results-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:5de797394e05e61b66b5b1dda7e509a08e7454a076e07a96e55b697cc8f4e616"},
+    {file = "pyats.results-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ee1bed08c3f18457372e9e5cc3f1a78cc5272cb13cfcb69ecc4de135f2fb026d"},
 ]
 "pyats.tcl" = [
-    {file = "pyats.tcl-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:bed091dbcc912d301522b4b15fcb4a3d66c4a981bca7f72bcd191527955a3206"},
-    {file = "pyats.tcl-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:a092cba0a833b35fa47a62fd95eaec0569420aa62a74fd1fbfd5e15445be5c2a"},
-    {file = "pyats.tcl-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:a4270030b9b9387118afdf9fd019dccb5867258bf3b7ca9716d2953348a05959"},
-    {file = "pyats.tcl-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:df39721a71d860cee3a54276a5c269790a606c6d85181330bfad93d5fb22e9bd"},
-    {file = "pyats.tcl-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:69597020518ba377fb364cb09b9af8c5a0eaeea9e26ea076e6a16367449f4154"},
-    {file = "pyats.tcl-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:bcfaa92d03a2a8dfcd5e0db5fd16990c512049cd6a20190f0e2d0b98f556a635"},
-    {file = "pyats.tcl-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:8a4d74098bf63131feff019f8216c78f50534846fff2b332d6fbd487b0a8e3d5"},
-    {file = "pyats.tcl-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:657be8753e8aef89c70c9628029519e692792dbe39a3668007745806628cba07"},
-    {file = "pyats.tcl-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:9c663ba8c62c2afeba46682326f9bb1ffaf41b329a5e87968367a64271babb47"},
-    {file = "pyats.tcl-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:317886517baf6eeb2a89cbb557b5002faa6bc16941d4c7ff76fe65edf88d3fec"},
-    {file = "pyats.tcl-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:4dfa1cc689217f95ffacf1208c602e015b31bae5de6b229d91d8ec437fa93252"},
-    {file = "pyats.tcl-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:ef5ab70c106b3054230694f2ccf769ef3ca9705914c3a2b444a2f5da93667e89"},
+    {file = "pyats.tcl-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:2f2da644608fe81d0786da779a5b1c7a0509570b2421d47aba40101cde39d6d0"},
+    {file = "pyats.tcl-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:ef84dff783532d5bd823b4adeb77df884ea0a1f8037e6d080851f2d50ce37c6f"},
+    {file = "pyats.tcl-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:bfae4cbb4a086d0fe58f43e87da38b398801d83f0f29928f68dcbd3bb599b154"},
+    {file = "pyats.tcl-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:629be89664795b4d2f3e3a62e5197320ad713535e8a9600be8952ed1c4515735"},
+    {file = "pyats.tcl-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:8ce5dd602ea51e4a785cde419288d5af224479dea49c0be1fba690657aaade88"},
+    {file = "pyats.tcl-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:0e82dd76cd4b5607dbdafbd3117c365f1fffd1f74b52cd419a4adf88fb07b914"},
+    {file = "pyats.tcl-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:c1e5dfafc4f17293ef0cdb3bb8213f251cb8d7c2213773d2a45d9e22b53d63d3"},
+    {file = "pyats.tcl-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6f5979543b83cb8d3a9f7ae81086c8a790b67f6ff8af927f09022f0c96bf4f0c"},
+    {file = "pyats.tcl-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:988b802f34c2338f64f5ec7559a18cd9cc70dabf514e2cc8cdf3fd3783119a56"},
+    {file = "pyats.tcl-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:008b2d10116642d8413754d349d4e47c40bf61157a8c732ba9df2c020c2aa2a9"},
+    {file = "pyats.tcl-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:288b60ec4592d21cc34c5abf6813ce840a7e12d9a1dedf6bcd0552dd783ee5cb"},
+    {file = "pyats.tcl-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4a47595e74ab6142df1d0536923a4caf2c09d165c274ca372569396e036bd483"},
 ]
 "pyats.topology" = [
-    {file = "pyats.topology-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:20efe1308b26572b422be9c5a8f37e6539c8635df87c4f6d8d5fc180c5c82316"},
-    {file = "pyats.topology-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:dcd86ebe3775cf9adb2488634587cd9ff9e9a8f2bfa472999c73ec973491f737"},
-    {file = "pyats.topology-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:6e6842f73078b502b5c926f87672fa0e7e5efe01c9077a171d7e2f3f97925a7f"},
-    {file = "pyats.topology-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:bdc1cfee0cc5891dabba415e06b6c1f998edde4c416e12b092d507b5ae346cc5"},
-    {file = "pyats.topology-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:539979ca4894bfd980dfc7f58e8f2805f2debbac9a21b45813f0f07d440e2c40"},
-    {file = "pyats.topology-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:533ce8054f818b64881b4ccd9445cf07786326b47e636781dc9c0f9acd0f459c"},
-    {file = "pyats.topology-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:d0c7a6578c069bff471a424b5e74d9206ed4c3f8b757d2e18013121666f663c0"},
-    {file = "pyats.topology-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:a9ef199773b68a111a838e50dea6b45099d86b0a2a78d0e3b0a5d89726d7b0e4"},
-    {file = "pyats.topology-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:a91526ba21ea99a5b9b2cd084ce61800e6806d72d180efccf344ac93f42bdc3d"},
-    {file = "pyats.topology-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:0156b061e6de06c38350677640c8d80b2137a4bbb1947392c774c11ef45d0a91"},
-    {file = "pyats.topology-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:47a2ea7b70d64dcd355e3ca617af100337a2d39e89feacb3d0ac2cbc6ec8fc81"},
-    {file = "pyats.topology-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:33056fdb31974d7f09afe5790062ee83017e708792e3fbe0a058ad966d1d20dd"},
+    {file = "pyats.topology-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:17e5ba5857677119837876c3532665e9ea1dcb9b0f7086a69fea1a67effdd39c"},
+    {file = "pyats.topology-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:5cb71a0f737427e4dda441425e79c31dab7dca24744b06c5e5b765480ee576d5"},
+    {file = "pyats.topology-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:7ed892cbb24c68d043df9bf68923bb86c911ce59099da486f78c195009a623f4"},
+    {file = "pyats.topology-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:17e40f7d7459290303073445406c902a65a902ce1ef8615bcad24f927caa02d5"},
+    {file = "pyats.topology-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:666cf7987ed20281b8e45a5dda0b5314b8715070e56a6b4b699304c970c8ea3d"},
+    {file = "pyats.topology-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:cd28fd4f9fa41bb703bdaf4efdecbe1887710f91d50c3d3ab40c6172f42b556e"},
+    {file = "pyats.topology-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:e1648a2a783bb34eda9d3e5d4a022ef3466d7db1ed88fdfc4450504f8b1a3bf4"},
+    {file = "pyats.topology-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:049d7bb0619840db46ad109f29f976cb249b69f9cc57b0aef3d38136bc800479"},
+    {file = "pyats.topology-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:841e2f6d48206b403984ee8a626cfd39d6a39a61a71d306828a6ea46ea99fed9"},
+    {file = "pyats.topology-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:5fee0c8079d5211de1f5668095666a7581978f20b32653f949864030f9f96bfa"},
+    {file = "pyats.topology-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:0bc5219f3672f37342597ddf8b246b3e648690e9f66cd4950c531c74c3e71c97"},
+    {file = "pyats.topology-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4f127e8f570b63108e611534e5c39da902a5bc460d2ad85d13990eb524b9c4b1"},
 ]
 "pyats.utils" = [
-    {file = "pyats.utils-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:c443e1d10f2affef4d9765080374829f823dc7db8c083c798d5afeff84a200a3"},
-    {file = "pyats.utils-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:e87f0cbbaf730363de8ab9981d194574907c8f0b950774811f355dc97b0cb20c"},
-    {file = "pyats.utils-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:08b60e80d1771ed16c6b7cbe6b32477d9b5503a4a650607d2d112862b3313d14"},
-    {file = "pyats.utils-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:27cf7499c8c073e790ad3ce9463a12850f69487a09a1d316528a946c0c3ae6d7"},
-    {file = "pyats.utils-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:2e973474a25eefad60f25c28f72f0cc5301811ae28e2c6d14ba5728827e0587c"},
-    {file = "pyats.utils-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:097b15fc58e87c90eb9283fbe2d418dcb87ae63085df89a274c861a36f0b9b00"},
-    {file = "pyats.utils-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:9a154671ad6165035c921957fa40354c0ea9db073d902e9e0963210418dfe00c"},
-    {file = "pyats.utils-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5e4fc285582bd0b83c6d26b1380d1f94f1e03e977216b9105c348a55beb37939"},
-    {file = "pyats.utils-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:6294f34d58a12eb9087c6513f31a0f47d50943b72601cc7ab6b39a4457d81cf6"},
-    {file = "pyats.utils-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:3cbe198dba576c094f1747715a8926b17559aded92774194a79f846ec8434f87"},
-    {file = "pyats.utils-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:b6a7b53b48e7b07e0a9aed2179e622ea655b73f1d63eff2afc6f09cc97c1790f"},
-    {file = "pyats.utils-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:79f5bc09c817d22beadcdecab7605c36a55bc6efba7a2306b606509e7aaa1cca"},
+    {file = "pyats.utils-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:e52d4b2110f048044258ce44fcb15a1dc92ed8cd5f926706cec92d3aa8264c3e"},
+    {file = "pyats.utils-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:51f3b072e29e4a797c11ec73c9e7f32676043c5c86bbb32a9074d833a0f97ddf"},
+    {file = "pyats.utils-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:e865e2fffea57eef74599435453977b0518b6319762f563bf4564ab3b43de99f"},
+    {file = "pyats.utils-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:08456e174c2c39c3c1cf40fea562f79cc07ebd0748b8850b76b86273495ce83b"},
+    {file = "pyats.utils-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:d0a585aa0863b87aa6ba13a6212236b124c4d13fa6bab65037b0f99bc1b4e653"},
+    {file = "pyats.utils-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:dc0c70e421e1ab37aef52286463027b8284beee8ad8b7cdb3c02e1656b27a79a"},
+    {file = "pyats.utils-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:2ce37a0203f465adb5b96b7c60670e2d96cfd12e8cd413b4c3266e55963e7c32"},
+    {file = "pyats.utils-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:412ae72db919735ae79104cd9fea5ae4e4f3965336af126ec16c9a41f6e1d29c"},
+    {file = "pyats.utils-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7a2a84339c96670708a3ffda9957b96d873a1fe05f7b0fd1fb45766226d0b87b"},
+    {file = "pyats.utils-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:23b59f2746b5f3096a7b0408dd9572885bc078e6b3a7e3be543cefe21158e7b3"},
+    {file = "pyats.utils-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:fb8215855ee740186a0f3957299e4b34815737a8d18eae40195784db016d722e"},
+    {file = "pyats.utils-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:438d7101e357ae97421005b4e51c730283c4a056f92b3020392bbc13013a6df0"},
 ]
 pybatfish = [
     {file = "pybatfish-2020.10.8.667-py2.py3-none-any.whl", hash = "sha256:17885a45ae644f965079540947b64d06d5ebc5f52ac841fc83e5a7ccd30bbc4f"},
@@ -2707,72 +2664,72 @@ pycparser = [
     {file = "pycparser-2.20.tar.gz", hash = "sha256:2d475327684562c3a96cc71adf7dc8c4f0565175cf86b6d7a404ff4c771f15f0"},
 ]
 pycryptodomex = [
-    {file = "pycryptodomex-3.9.8-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:c0d085c8187a1e4d3402f626c9e438b5861151ab132d8761d9c5ce6491a87761"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:1714675fb4ac29a26ced38ca22eb8ffd923ac851b7a6140563863194d7158422"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:c990f2c58f7c67688e9e86e6557ed05952669ff6f1343e77b459007d85f7df00"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27m-win32.whl", hash = "sha256:9fd758e5e2fe02d57860b85da34a1a1e7037155c4eadc2326fc7af02f9cae214"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27m-win_amd64.whl", hash = "sha256:b2d756620078570d3f940c84bc94dd30aa362b795cce8b2723300a8800b87f1c"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:2710fc8d83b3352b370db932b3710033b9d630b970ff5aaa3e7458b5336e3b32"},
-    {file = "pycryptodomex-3.9.8-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:2199708ebeed4b82eb45b10e1754292677f5a0df7d627ee91ea01290b9bab7e6"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:8044eae59301dd392fbb4a7c5d64e1aea8ef0be2540549807ecbe703d6233d68"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:06f5a458624c9b0e04c0086c7f84bcc578567dab0ddc816e0476b3057b18339f"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:ccbbec59bf4b74226170c54476da5780c9176bae084878fc94d9a2c841218e34"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:3b23d63030819b7d9ac7db9360305fd1241e6870ca5b7e8d59fee4db4674a490"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-win32.whl", hash = "sha256:e4e1c486bf226822c8dceac81d0ec59c0a2399dbd1b9e04f03c3efa3605db677"},
-    {file = "pycryptodomex-3.9.8-cp35-cp35m-win_amd64.whl", hash = "sha256:2275a663c9e744ee4eace816ef2d446b3060554c5773a92fbc79b05bf47debda"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:93a75d1acd54efed314b82c952b39eac96ce98d241ad7431547442e5c56138aa"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:e42860fbe1292668b682f6dabd225fbe2a7a4fa1632f0c39881c019e93dea594"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:f60b3484ce4be04f5da3777c51c5140d3fe21cdd6674f2b6568f41c8130bcdeb"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:c315262e26d54a9684e323e37ac9254f481d57fcc4fd94002992460898ef5c04"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-win32.whl", hash = "sha256:a2ee8ba99d33e1a434fcd27d7d0aa7964163efeee0730fe2efc9d60edae1fc71"},
-    {file = "pycryptodomex-3.9.8-cp36-cp36m-win_amd64.whl", hash = "sha256:58e19560814dabf5d788b95a13f6b98279cf41a49b1e49ee6cf6c79a57adb4c9"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:a2bc4e1a2e6ca3a18b2e0be6131a23af76fecb37990c159df6edc7da6df913e3"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4e0b27697fa1621c6d3d3b4edeec723c2e841285de6a8d378c1962da77b349be"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:3caa32cf807422adf33c10c88c22e9e2e08b9d9d042f12e1e25fe23113dd618f"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:ddb1ae2891c8cb83a25da87a3e00111a9654fc5f0b70f18879c41aece45d6182"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-win32.whl", hash = "sha256:89be1bf55e50116fe7e493a7c0c483099770dd7f81b87ac8d04a43b1a203e259"},
-    {file = "pycryptodomex-3.9.8-cp37-cp37m-win_amd64.whl", hash = "sha256:17272d06e4b2f6455ee2cbe93e8eb50d9450a5dc6223d06862ee1ea5d1235861"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:ea4d4b58f9bc34e224ef4b4604a6be03d72ef1f8c486391f970205f6733dbc46"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8fcdda24dddf47f716400d54fc7f75cadaaba1dd47cc127e59d752c9c0fc3c48"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4ae6379350a09339109e9b6f419bb2c3f03d3e441f4b0f5b8ca699d47cc9ff7e"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:85c108b42e47d4073344ff61d4e019f1d95bb7725ca0fe87d0a2deb237c10e49"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-win32.whl", hash = "sha256:dc2bed32c7b138f1331794e454a953360c8cedf3ee62ae31f063822da6007489"},
-    {file = "pycryptodomex-3.9.8-cp38-cp38-win_amd64.whl", hash = "sha256:914fbb18e29c54585e6aa39d300385f90d0fa3b3cc02ed829b08f95c1acf60c2"},
-    {file = "pycryptodomex-3.9.8-cp39-cp39-manylinux1_i686.whl", hash = "sha256:35b9c9177a9fe7288b19dd41554c9c8ca1063deb426dd5a02e7e2a7416b6bd11"},
-    {file = "pycryptodomex-3.9.8-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:e070a1f91202ed34c396be5ea842b886f6fa2b90d2db437dc9fb35a26c80c060"},
-    {file = "pycryptodomex-3.9.8-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f5bd6891380e0fb5467251daf22525644fdf6afd9ae8bc2fe065c78ea1882e0d"},
-    {file = "pycryptodomex-3.9.8.tar.gz", hash = "sha256:48cc2cfc251f04a6142badeb666d1ff49ca6fdfc303fd72579f62b768aaa52b9"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27m-macosx_10_6_intel.whl", hash = "sha256:5e486cab2dfcfaec934dd4f5d5837f4a9428b690f4d92a3b020fd31d1497ca64"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27m-manylinux1_i686.whl", hash = "sha256:42669638e4f7937b7141044a2fbd1019caca62bd2cdd8b535f731426ab07bde1"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27m-manylinux1_x86_64.whl", hash = "sha256:4ce1fc1e6d2fd2d6dc197607153327989a128c093e0e94dca63408f506622c3e"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27m-win32.whl", hash = "sha256:d2d1388595cb5d27d9220d5cbaff4f37c6ec696a25882eb06d224d241e6e93fb"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27m-win_amd64.whl", hash = "sha256:a1d38a96da57e6103423a446079ead600b450cf0f8ebf56a231895abf77e7ffc"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27mu-manylinux1_i686.whl", hash = "sha256:934e460c5058346c6f1d62fdf3db5680fbdfbfd212722d24d8277bf47cd9ebdc"},
+    {file = "pycryptodomex-3.9.9-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:3642252d7bfc4403a42050e18ba748bedebd5a998a8cba89665a4f42aea4c380"},
+    {file = "pycryptodomex-3.9.9-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:a385fceaa0cdb97f0098f1c1e9ec0b46cc09186ddf60ec23538e871b1dddb6dc"},
+    {file = "pycryptodomex-3.9.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73240335f4a1baf12880ebac6df66ab4d3a9212db9f3efe809c36a27280d16f8"},
+    {file = "pycryptodomex-3.9.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:305e3c46f20d019cd57543c255e7ba49e432e275d7c0de8913b6dbe57a851bc8"},
+    {file = "pycryptodomex-3.9.9-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:871852044f55295449fbf225538c2c4118525093c32f0a6c43c91bed0452d7e3"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-macosx_10_6_intel.whl", hash = "sha256:4632d55a140b28e20be3cd7a3057af52fb747298ff0fd3290d4e9f245b5004ba"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a9aac1a30b00b5038d3d8e48248f3b58ea15c827b67325c0d18a447552e30fc8"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:a7cf1c14e47027d9fb9d26aa62e5d603994227bd635e58a8df4b1d2d1b6a8ed7"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:20fb7f4efc494016eab1bc2f555bc0a12dd5ca61f35c95df8061818ffb2c20a3"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-win32.whl", hash = "sha256:892e93f3e7e10c751d6c17fa0dc422f7984cfd5eb6690011f9264dc73e2775fc"},
+    {file = "pycryptodomex-3.9.9-cp36-cp36m-win_amd64.whl", hash = "sha256:28ee3bcb4d609aea3040cad995a8e2c9c6dc57c12183dadd69e53880c35333b9"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-macosx_10_6_intel.whl", hash = "sha256:d62fbab185a6b01c5469eda9f0795f3d1a5bba24f5a5813f362e4b73a3c4dc70"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:bef9e9d39393dc7baec39ba4bac6c73826a4db02114cdeade2552a9d6afa16e2"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:f20a62397e09704049ce9007bea4f6bad965ba9336a760c6f4ef1b4192e12d6d"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:c885fe4d5f26ce8ca20c97d02e88f5fdd92c01e1cc771ad0951b21e1641faf6d"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-win32.whl", hash = "sha256:f81f7311250d9480e36dec819127897ae772e7e8de07abfabe931b8566770b8e"},
+    {file = "pycryptodomex-3.9.9-cp37-cp37m-win_amd64.whl", hash = "sha256:55cf4e99b3ba0122dee570dc7661b97bf35c16aab3e2ccb5070709d282a1c7ab"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:15c03ffdac17731b126880622823d30d0a3cc7203cd219e6b9814140a44e7fab"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:3547b87b16aad6afb28c9b3a9cd870e11b5e7b5ac649b74265258d96d8de1130"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:65ec88c8271448d2ea109d35c1f297b09b872c57214ab7e832e413090d3469a9"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:404faa3e518f8bea516aae2aac47d4d960397199a15b4bd6f66cad97825469a0"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-win32.whl", hash = "sha256:d2e853e0f9535e693fade97768cf7293f3febabecc5feb1e9b2ffdfe1044ab96"},
+    {file = "pycryptodomex-3.9.9-cp38-cp38-win_amd64.whl", hash = "sha256:836fe39282e75311ce4c38468be148f7fac0df3d461c5de58c5ff1ddb8966bac"},
+    {file = "pycryptodomex-3.9.9-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4a88c9383d273bdce3afc216020282c9c5c39ec0bd9462b1a206af6afa377cf0"},
+    {file = "pycryptodomex-3.9.9-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:9736f3f3e1761024200637a080a4f922f5298ad5d780e10dbb5634fe8c65b34c"},
+    {file = "pycryptodomex-3.9.9-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:6c95a3361ce70068cf69526a58751f73ddac5ba27a3c2379b057efa2f5338c8c"},
+    {file = "pycryptodomex-3.9.9-cp39-cp39-win32.whl", hash = "sha256:b696876ee583d15310be57311e90e153a84b7913ac93e6b99675c0c9867926d0"},
+    {file = "pycryptodomex-3.9.9-cp39-cp39-win_amd64.whl", hash = "sha256:7651211e15109ac0058a49159265d9f6e6423c8a81c65434d3c56d708417a05b"},
+    {file = "pycryptodomex-3.9.9.tar.gz", hash = "sha256:7b5b7c5896f8172ea0beb283f7f9428e0ab88ec248ce0a5b8c98d73e26267d51"},
 ]
 pydantic = [
-    {file = "pydantic-1.7-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:fde17f99d1610c9b5129f5b37d9ae6d549e0cc6108df991e2c14c7c99d406a89"},
-    {file = "pydantic-1.7-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:caa14909e26c69585628dcc5c97d5a26bcc447eca4baaf3a646a9919ff91ac69"},
-    {file = "pydantic-1.7-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:22ed6db2a6d6b40350078eb3bb71e6923e4e994678feda220d28f1c30da0b8da"},
-    {file = "pydantic-1.7-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:d024440c27d4d0fb862b279e43d2b3f5c5e5680e0627de8f7ca60e471457032e"},
-    {file = "pydantic-1.7-cp36-cp36m-win_amd64.whl", hash = "sha256:afe2cafc41249464ad42cf2302128baa796f037099fc3b9eaa54d1b873529c67"},
-    {file = "pydantic-1.7-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:471ef129991cc2c965bef11eacb4bd5451baa0b60b4bbe1bc47e40a760facb88"},
-    {file = "pydantic-1.7-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:e687492a769f13c8c96f8c657720a41137be65b8682a6fce5241e0a37d500bc4"},
-    {file = "pydantic-1.7-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:f0747f01aa95f1c561e6e64f8e06433d37ea4ac386519bcaddfd8f18e3ebc6fc"},
-    {file = "pydantic-1.7-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:9143f236e1969a501bbedbeb70aa6e85b6940fc84a06effba620620d68c2bee6"},
-    {file = "pydantic-1.7-cp37-cp37m-win_amd64.whl", hash = "sha256:1d9a6484f1690c94ee7851f74a75eae41980b9f07b8931e14225c050a5eaa821"},
-    {file = "pydantic-1.7-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:1724517b6205ce02be6b8f8bf70ec9cb52b94cf40ab9dec7a7609bcf5254e2d2"},
-    {file = "pydantic-1.7-cp38-cp38-manylinux1_i686.whl", hash = "sha256:bc1fca601c7c67231464f0be5594942ec7da9ba3a4ee2e3533f02802a7cc8e65"},
-    {file = "pydantic-1.7-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:17c199147b4f1d43f40ee7e735ccaff45f09e90ad54cebff8676bedb4f159634"},
-    {file = "pydantic-1.7-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:7d0d84401597734097a9c4681556769168de3d1acfc14fdc5c13e523414f9ecc"},
-    {file = "pydantic-1.7-cp38-cp38-win_amd64.whl", hash = "sha256:b6d70d28aef95cebd8761818b4dfeb6bdbb71a68c1f4beb8983f083c630d57ee"},
-    {file = "pydantic-1.7-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:d5a131a5be9eee7172b98c680dc26f2382e66071c4848eb310c3cce00aeee4df"},
-    {file = "pydantic-1.7-cp39-cp39-manylinux1_i686.whl", hash = "sha256:8bd368a22f6a8dce262f7672c2cf06460a6ab0486fbfa8f6482d325d34277075"},
-    {file = "pydantic-1.7-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:8e30ee558b295ef12572d0a9a3a35a2d33115f280e051e0b816c4b2448f0cb63"},
-    {file = "pydantic-1.7-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:a3087623f8aa1795ebc3a69eb94683772db0943a4adef1bf5e9553effaafea93"},
-    {file = "pydantic-1.7-cp39-cp39-win_amd64.whl", hash = "sha256:7feac9bd1078adf7ae705c8c092b3ea5ada05318b38fd5e708cfce9f167dbeb8"},
-    {file = "pydantic-1.7-py3-none-any.whl", hash = "sha256:e43b66bf115860e7ef10efb8dd07a831d57c38df1efe475789c34c55067fb7fd"},
-    {file = "pydantic-1.7.tar.gz", hash = "sha256:38ee226f71dfbb7b91bc3d8af9932bf18c7505e57f7ed442e8cb78ff35c006a7"},
+    {file = "pydantic-1.7.3-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:c59ea046aea25be14dc22d69c97bee629e6d48d2b2ecb724d7fe8806bf5f61cd"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a4143c8d0c456a093387b96e0f5ee941a950992904d88bc816b4f0e72c9a0009"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:d8df4b9090b595511906fa48deda47af04e7d092318bfb291f4d45dfb6bb2127"},
+    {file = "pydantic-1.7.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:514b473d264671a5c672dfb28bdfe1bf1afd390f6b206aa2ec9fed7fc592c48e"},
+    {file = "pydantic-1.7.3-cp36-cp36m-win_amd64.whl", hash = "sha256:dba5c1f0a3aeea5083e75db9660935da90216f8a81b6d68e67f54e135ed5eb23"},
+    {file = "pydantic-1.7.3-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:59e45f3b694b05a69032a0d603c32d453a23f0de80844fb14d55ab0c6c78ff2f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:5b24e8a572e4b4c18f614004dda8c9f2c07328cb5b6e314d6e1bbd536cb1a6c1"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:b2b054d095b6431cdda2f852a6d2f0fdec77686b305c57961b4c5dd6d863bf3c"},
+    {file = "pydantic-1.7.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:025bf13ce27990acc059d0c5be46f416fc9b293f45363b3d19855165fee1874f"},
+    {file = "pydantic-1.7.3-cp37-cp37m-win_amd64.whl", hash = "sha256:6e3874aa7e8babd37b40c4504e3a94cc2023696ced5a0500949f3347664ff8e2"},
+    {file = "pydantic-1.7.3-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:e682f6442ebe4e50cb5e1cfde7dda6766fb586631c3e5569f6aa1951fd1a76ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:185e18134bec5ef43351149fe34fda4758e53d05bb8ea4d5928f0720997b79ef"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:f5b06f5099e163295b8ff5b1b71132ecf5866cc6e7f586d78d7d3fd6e8084608"},
+    {file = "pydantic-1.7.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:24ca47365be2a5a3cc3f4a26dcc755bcdc9f0036f55dcedbd55663662ba145ec"},
+    {file = "pydantic-1.7.3-cp38-cp38-win_amd64.whl", hash = "sha256:d1fe3f0df8ac0f3a9792666c69a7cd70530f329036426d06b4f899c025aca74e"},
+    {file = "pydantic-1.7.3-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:f6864844b039805add62ebe8a8c676286340ba0c6d043ae5dea24114b82a319e"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:ecb54491f98544c12c66ff3d15e701612fc388161fd455242447083350904730"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:ffd180ebd5dd2a9ac0da4e8b995c9c99e7c74c31f985ba090ee01d681b1c4b95"},
+    {file = "pydantic-1.7.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8d72e814c7821125b16f1553124d12faba88e85405b0864328899aceaad7282b"},
+    {file = "pydantic-1.7.3-cp39-cp39-win_amd64.whl", hash = "sha256:475f2fa134cf272d6631072554f845d0630907fce053926ff634cc6bc45bf1af"},
+    {file = "pydantic-1.7.3-py3-none-any.whl", hash = "sha256:38be427ea01a78206bcaf9a56f835784afcba9e5b88fbdce33bbbfbcd7841229"},
+    {file = "pydantic-1.7.3.tar.gz", hash = "sha256:213125b7e9e64713d16d988d10997dabc6a1f73f3991e1ff8e35ebb1409c7dc9"},
 ]
 pydocstyle = [
     {file = "pydocstyle-5.1.1-py3-none-any.whl", hash = "sha256:aca749e190a01726a4fb472dd4ef23b5c9da7b9205c0a7857c06533de13fd678"},
     {file = "pydocstyle-5.1.1.tar.gz", hash = "sha256:19b86fa8617ed916776a11cd8bc0197e5b9856d5433b777f51a3defe13075325"},
 ]
 pyeapi = [
-    {file = "pyeapi-0.8.3.tar.gz", hash = "sha256:b90f9463ffad72df0c6179f4b1c248785f42206f7c43655da1217e368a992479"},
+    {file = "pyeapi-0.8.4.tar.gz", hash = "sha256:c33ad1eadd8ebac75f63488df9412081ce0b024c9e1da12a37196a5c60427c54"},
 ]
 pyflakes = [
     {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
@@ -2798,8 +2755,6 @@ pynacl = [
     {file = "PyNaCl-1.4.0-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:7757ae33dae81c300487591c68790dfb5145c7d03324000433d9a2c141f82af7"},
     {file = "PyNaCl-1.4.0-cp35-abi3-macosx_10_10_x86_64.whl", hash = "sha256:757250ddb3bff1eecd7e41e65f7f833a8405fede0194319f87899690624f2122"},
     {file = "PyNaCl-1.4.0-cp35-abi3-manylinux1_x86_64.whl", hash = "sha256:30f9b96db44e09b3304f9ea95079b1b7316b2b4f3744fe3aaecccd95d547063d"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win32.whl", hash = "sha256:4e10569f8cbed81cb7526ae137049759d2a8d57726d52c1a000a3ce366779634"},
-    {file = "PyNaCl-1.4.0-cp35-abi3-win_amd64.whl", hash = "sha256:c914f78da4953b33d4685e3cdc7ce63401247a21425c16a39760e282075ac4a6"},
     {file = "PyNaCl-1.4.0-cp35-cp35m-win32.whl", hash = "sha256:06cbb4d9b2c4bd3c8dc0d267416aaed79906e7b33f114ddbf0911969794b1cc4"},
     {file = "PyNaCl-1.4.0-cp35-cp35m-win_amd64.whl", hash = "sha256:511d269ee845037b95c9781aa702f90ccc36036f95d0f31373a6a79bd8242e25"},
     {file = "PyNaCl-1.4.0-cp36-cp36m-win32.whl", hash = "sha256:11335f09060af52c97137d4ac54285bcb7df0cef29014a1a4efe64ac065434c4"},
@@ -2826,12 +2781,9 @@ pyreadline = [
 pyrepl = [
     {file = "pyrepl-0.9.0.tar.gz", hash = "sha256:292570f34b5502e871bbb966d639474f2b57fbfcd3373c2d6a2f3d56e681a775"},
 ]
-pyrsistent = [
-    {file = "pyrsistent-0.17.3.tar.gz", hash = "sha256:2e636185d9eb976a18a8a8e96efce62f2905fea90041958d8cc2a189756ebf3e"},
-]
 pyserial = [
-    {file = "pyserial-3.4-py2.py3-none-any.whl", hash = "sha256:e0770fadba80c31013896c7e6ef703f72e7834965954a78e71a3049488d4d7d8"},
-    {file = "pyserial-3.4.tar.gz", hash = "sha256:6e2d401fdee0eab996cf734e67773a0143b932772ca8b42451440cfed942c627"},
+    {file = "pyserial-3.5-py2.py3-none-any.whl", hash = "sha256:c4451db6ba391ca6ca299fb3ec7bae67a5c55dde170964c7a14ceefec02f2cf0"},
+    {file = "pyserial-3.5.tar.gz", hash = "sha256:3c77e014170dfffbd816e6ffc205e9842efb10be9f58ec16d3e8675b4925cddb"},
 ]
 pysmi = [
     {file = "pysmi-0.3.4-py2.4.egg", hash = "sha256:13d937620529468d34d525089abbd569f3b34dd808085d34586e63fbbda40fdb"},
@@ -2872,16 +2824,16 @@ python-dateutil = [
     {file = "python_dateutil-2.8.1-py2.py3-none-any.whl", hash = "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"},
 ]
 python-engineio = [
-    {file = "python-engineio-3.13.2.tar.gz", hash = "sha256:36b33c6aa702d9b6a7f527eec6387a2da1a9a24484ec2f086d76576413cef04b"},
-    {file = "python_engineio-3.13.2-py2.py3-none-any.whl", hash = "sha256:cfded18156862f94544a9f8ef37f56727df731c8552d7023f5afee8369be2db6"},
+    {file = "python-engineio-3.14.2.tar.gz", hash = "sha256:eab4553f2804c1ce97054c8b22cf0d5a9ab23128075248b97e1a5b2f29553085"},
+    {file = "python_engineio-3.14.2-py2.py3-none-any.whl", hash = "sha256:5a9e6086d192463b04a1428ff1f85b6ba631bbb19d453b144ffc04f530542b84"},
 ]
 python-socketio = [
-    {file = "python-socketio-4.6.0.tar.gz", hash = "sha256:358d8fbbc029c4538ea25bcaa283e47f375be0017fcba829de8a3a731c9df25a"},
-    {file = "python_socketio-4.6.0-py2.py3-none-any.whl", hash = "sha256:d437f797c44b6efba2f201867cf02b8c96b97dff26d4e4281ac08b45817cd522"},
+    {file = "python-socketio-4.6.1.tar.gz", hash = "sha256:cd1f5aa492c1eb2be77838e837a495f117e17f686029ebc03d62c09e33f4fa10"},
+    {file = "python_socketio-4.6.1-py2.py3-none-any.whl", hash = "sha256:5a21da53fdbdc6bb6c8071f40e13d100e0b279ad997681c2492478e06f370523"},
 ]
 pytz = [
-    {file = "pytz-2020.1-py2.py3-none-any.whl", hash = "sha256:a494d53b6d39c3c6e44c3bec237336e14305e4f29bbf800b599253057fbb79ed"},
-    {file = "pytz-2020.1.tar.gz", hash = "sha256:c35965d010ce31b23eeb663ed3cc8c906275d6be1a34393a1d73a41febf4a048"},
+    {file = "pytz-2020.4-py2.py3-none-any.whl", hash = "sha256:5c55e189b682d420be27c6995ba6edce0c0a77dd67bfbe2ae6607134d5851ffd"},
+    {file = "pytz-2020.4.tar.gz", hash = "sha256:3e6b7dd2d1e0a59084bcee14a17af60c5c562cdc16d828e8eba2e683d3a7e268"},
 ]
 pyyaml = [
     {file = "PyYAML-5.3.1-cp27-cp27m-win32.whl", hash = "sha256:74809a57b329d6cc0fdccee6318f44b9b8649961fa73144a98735b0aaf029f1f"},
@@ -2894,42 +2846,54 @@ pyyaml = [
     {file = "PyYAML-5.3.1-cp37-cp37m-win_amd64.whl", hash = "sha256:73f099454b799e05e5ab51423c7bcf361c58d3206fa7b0d555426b1f4d9a3eaf"},
     {file = "PyYAML-5.3.1-cp38-cp38-win32.whl", hash = "sha256:06a0d7ba600ce0b2d2fe2e78453a470b5a6e000a985dd4a4e54e436cc36b0e97"},
     {file = "PyYAML-5.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:95f71d2af0ff4227885f7a6605c37fd53d3a106fcab511b8860ecca9fcf400ee"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win32.whl", hash = "sha256:ad9c67312c84def58f3c04504727ca879cb0013b2517c85a9a253f0cb6380c0a"},
-    {file = "PyYAML-5.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6034f55dab5fea9e53f436aa68fa3ace2634918e8b5994d82f3621c04ff5ed2e"},
     {file = "PyYAML-5.3.1.tar.gz", hash = "sha256:b8eac752c5e14d3eca0e6dd9199cd627518cb5ec06add0de9d32baeee6fe645d"},
 ]
 regex = [
-    {file = "regex-2020.10.23-cp27-cp27m-win32.whl", hash = "sha256:781906e45ef1d10a0ed9ec8ab83a09b5e0d742de70e627b20d61ccb1b1d3964d"},
-    {file = "regex-2020.10.23-cp27-cp27m-win_amd64.whl", hash = "sha256:8cd0d587aaac74194ad3e68029124c06245acaeddaae14cb45844e5c9bebeea4"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:af360e62a9790e0a96bc9ac845d87bfa0e4ee0ee68547ae8b5a9c1030517dbef"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:4e21340c07090ddc8c16deebfd82eb9c9e1ec5e62f57bb86194a2595fd7b46e0"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:e5f6aa56dda92472e9d6f7b1e6331f4e2d51a67caafff4d4c5121cadac03941e"},
-    {file = "regex-2020.10.23-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:c30d8766a055c22e39dd7e1a4f98f6266169f2de05db737efe509c2fb9c8a3c8"},
-    {file = "regex-2020.10.23-cp36-cp36m-win32.whl", hash = "sha256:1a065e7a6a1b4aa851a0efa1a2579eabc765246b8b3a5fd74000aaa3134b8b4e"},
-    {file = "regex-2020.10.23-cp36-cp36m-win_amd64.whl", hash = "sha256:c95d514093b80e5309bdca5dd99e51bcf82c44043b57c34594d9d7556bd04d05"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:f4b1c65ee86bfbf7d0c3dfd90592a9e3d6e9ecd36c367c884094c050d4c35d04"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:d62205f00f461fe8b24ade07499454a3b7adf3def1225e258b994e2215fd15c5"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:b706c70070eea03411b1761fff3a2675da28d042a1ab7d0863b3efe1faa125c9"},
-    {file = "regex-2020.10.23-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:d43cf21df524283daa80ecad551c306b7f52881c8d0fe4e3e76a96b626b6d8d8"},
-    {file = "regex-2020.10.23-cp37-cp37m-win32.whl", hash = "sha256:570e916a44a361d4e85f355aacd90e9113319c78ce3c2d098d2ddf9631b34505"},
-    {file = "regex-2020.10.23-cp37-cp37m-win_amd64.whl", hash = "sha256:1c447b0d108cddc69036b1b3910fac159f2b51fdeec7f13872e059b7bc932be1"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux1_i686.whl", hash = "sha256:8469377a437dbc31e480993399fd1fd15fe26f382dc04c51c9cb73e42965cc06"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:59d5c6302d22c16d59611a9fd53556554010db1d47e9df5df37be05007bebe75"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:a973d5a7a324e2a5230ad7c43f5e1383cac51ef4903bf274936a5634b724b531"},
-    {file = "regex-2020.10.23-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:97a023f97cddf00831ba04886d1596ef10f59b93df7f855856f037190936e868"},
-    {file = "regex-2020.10.23-cp38-cp38-win32.whl", hash = "sha256:e289a857dca3b35d3615c3a6a438622e20d1bf0abcb82c57d866c8d0be3f44c4"},
-    {file = "regex-2020.10.23-cp38-cp38-win_amd64.whl", hash = "sha256:0cb23ed0e327c18fb7eac61ebbb3180ebafed5b9b86ca2e15438201e5903b5dd"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c53dc8ee3bb7b7e28ee9feb996a0c999137be6c1d3b02cb6b3c4cba4f9e5ed09"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:6a46eba253cedcbe8a6469f881f014f0a98819d99d341461630885139850e281"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:240509721a663836b611fa13ca1843079fc52d0b91ef3f92d9bba8da12e768a0"},
-    {file = "regex-2020.10.23-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:6f567df0601e9c7434958143aebea47a9c4b45434ea0ae0286a4ec19e9877169"},
-    {file = "regex-2020.10.23-cp39-cp39-win32.whl", hash = "sha256:bfd7a9fddd11d116a58b62ee6c502fd24cfe22a4792261f258f886aa41c2a899"},
-    {file = "regex-2020.10.23-cp39-cp39-win_amd64.whl", hash = "sha256:1a511470db3aa97432ac8c1bf014fcc6c9fbfd0f4b1313024d342549cf86bcd6"},
-    {file = "regex-2020.10.23.tar.gz", hash = "sha256:2278453c6a76280b38855a263198961938108ea2333ee145c5168c36b8e2b376"},
+    {file = "regex-2020.11.13-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:8b882a78c320478b12ff024e81dc7d43c1462aa4a3341c754ee65d857a521f85"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:a63f1a07932c9686d2d416fb295ec2c01ab246e89b4d58e5fa468089cab44b70"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:6e4b08c6f8daca7d8f07c8d24e4331ae7953333dbd09c648ed6ebd24db5a10ee"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_i686.whl", hash = "sha256:bba349276b126947b014e50ab3316c027cac1495992f10e5682dc677b3dfa0c5"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2010_x86_64.whl", hash = "sha256:56e01daca75eae420bce184edd8bb341c8eebb19dd3bce7266332258f9fb9dd7"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:6a8ce43923c518c24a2579fda49f093f1397dad5d18346211e46f134fc624e31"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:1ab79fcb02b930de09c76d024d279686ec5d532eb814fd0ed1e0051eb8bd2daa"},
+    {file = "regex-2020.11.13-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:9801c4c1d9ae6a70aeb2128e5b4b68c45d4f0af0d1535500884d644fa9b768c6"},
+    {file = "regex-2020.11.13-cp36-cp36m-win32.whl", hash = "sha256:49cae022fa13f09be91b2c880e58e14b6da5d10639ed45ca69b85faf039f7a4e"},
+    {file = "regex-2020.11.13-cp36-cp36m-win_amd64.whl", hash = "sha256:749078d1eb89484db5f34b4012092ad14b327944ee7f1c4f74d6279a6e4d1884"},
+    {file = "regex-2020.11.13-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:b2f4007bff007c96a173e24dcda236e5e83bde4358a557f9ccf5e014439eae4b"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:38c8fd190db64f513fe4e1baa59fed086ae71fa45083b6936b52d34df8f86a88"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:5862975b45d451b6db51c2e654990c1820523a5b07100fc6903e9c86575202a0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_i686.whl", hash = "sha256:262c6825b309e6485ec2493ffc7e62a13cf13fb2a8b6d212f72bd53ad34118f1"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2010_x86_64.whl", hash = "sha256:bafb01b4688833e099d79e7efd23f99172f501a15c44f21ea2118681473fdba0"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:e32f5f3d1b1c663af7f9c4c1e72e6ffe9a78c03a31e149259f531e0fed826512"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:3bddc701bdd1efa0d5264d2649588cbfda549b2899dc8d50417e47a82e1387ba"},
+    {file = "regex-2020.11.13-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:02951b7dacb123d8ea6da44fe45ddd084aa6777d4b2454fa0da61d569c6fa538"},
+    {file = "regex-2020.11.13-cp37-cp37m-win32.whl", hash = "sha256:0d08e71e70c0237883d0bef12cad5145b84c3705e9c6a588b2a9c7080e5af2a4"},
+    {file = "regex-2020.11.13-cp37-cp37m-win_amd64.whl", hash = "sha256:1fa7ee9c2a0e30405e21031d07d7ba8617bc590d391adfc2b7f1e8b99f46f444"},
+    {file = "regex-2020.11.13-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:baf378ba6151f6e272824b86a774326f692bc2ef4cc5ce8d5bc76e38c813a55f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_i686.whl", hash = "sha256:e3faaf10a0d1e8e23a9b51d1900b72e1635c2d5b0e1bea1c18022486a8e2e52d"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:2a11a3e90bd9901d70a5b31d7dd85114755a581a5da3fc996abfefa48aee78af"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_i686.whl", hash = "sha256:d1ebb090a426db66dd80df8ca85adc4abfcbad8a7c2e9a5ec7513ede522e0a8f"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2010_x86_64.whl", hash = "sha256:b2b1a5ddae3677d89b686e5c625fc5547c6e492bd755b520de5332773a8af06b"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:2c99e97d388cd0a8d30f7c514d67887d8021541b875baf09791a3baad48bb4f8"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:c084582d4215593f2f1d28b65d2a2f3aceff8342aa85afd7be23a9cad74a0de5"},
+    {file = "regex-2020.11.13-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:a3d748383762e56337c39ab35c6ed4deb88df5326f97a38946ddd19028ecce6b"},
+    {file = "regex-2020.11.13-cp38-cp38-win32.whl", hash = "sha256:7913bd25f4ab274ba37bc97ad0e21c31004224ccb02765ad984eef43e04acc6c"},
+    {file = "regex-2020.11.13-cp38-cp38-win_amd64.whl", hash = "sha256:6c54ce4b5d61a7129bad5c5dc279e222afd00e721bf92f9ef09e4fae28755683"},
+    {file = "regex-2020.11.13-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:1862a9d9194fae76a7aaf0150d5f2a8ec1da89e8b55890b1786b8f88a0f619dc"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_i686.whl", hash = "sha256:4902e6aa086cbb224241adbc2f06235927d5cdacffb2425c73e6570e8d862364"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:7a25fcbeae08f96a754b45bdc050e1fb94b95cab046bf56b016c25e9ab127b3e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_i686.whl", hash = "sha256:d2d8ce12b7c12c87e41123997ebaf1a5767a5be3ec545f64675388970f415e2e"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2010_x86_64.whl", hash = "sha256:f7d29a6fc4760300f86ae329e3b6ca28ea9c20823df123a2ea8693e967b29917"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:717881211f46de3ab130b58ec0908267961fadc06e44f974466d1887f865bd5b"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:3128e30d83f2e70b0bed9b2a34e92707d0877e460b402faca908c6667092ada9"},
+    {file = "regex-2020.11.13-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:8f6a2229e8ad946e36815f2a03386bb8353d4bde368fdf8ca5f0cb97264d3b5c"},
+    {file = "regex-2020.11.13-cp39-cp39-win32.whl", hash = "sha256:f8f295db00ef5f8bae530fc39af0b40486ca6068733fb860b42115052206466f"},
+    {file = "regex-2020.11.13-cp39-cp39-win_amd64.whl", hash = "sha256:a15f64ae3a027b64496a71ab1f722355e570c3fac5ba2801cafce846bf5af01d"},
+    {file = "regex-2020.11.13.tar.gz", hash = "sha256:83d6b356e116ca119db8e7c6fc2983289d87b27b3fac238cfe5dca529d884562"},
 ]
 requests = [
-    {file = "requests-2.24.0-py2.py3-none-any.whl", hash = "sha256:fe75cc94a9443b9246fc7049224f75604b113c36acb93f87b80ed42c44cbb898"},
-    {file = "requests-2.24.0.tar.gz", hash = "sha256:b3559a131db72c33ee969480840fff4bb6dd111de7dd27c8ee1f820f4f00231b"},
+    {file = "requests-2.25.0-py2.py3-none-any.whl", hash = "sha256:e786fa28d8c9154e6a4de5d46a1d921b8749f8b74e28bde23768e5e16eece998"},
+    {file = "requests-2.25.0.tar.gz", hash = "sha256:7f1a0b932f4a60a1a65caa4263921bb7d9ee911957e0ae4a23a6dd08185ad5f8"},
 ]
 requests-mock = [
     {file = "requests-mock-1.8.0.tar.gz", hash = "sha256:e68f46844e4cee9d447150343c9ae875f99fa8037c6dcf5f15bf1fe9ab43d226"},
@@ -2940,8 +2904,8 @@ requests-toolbelt = [
     {file = "requests_toolbelt-0.9.1-py2.py3-none-any.whl", hash = "sha256:380606e1d10dc85c3bd47bf5a6095f815ec007be7a8b69c878507068df059e6f"},
 ]
 rich = [
-    {file = "rich-9.2.0-py3-none-any.whl", hash = "sha256:564fee761e0756c3a4fbe97517166703754e11b4e861983cf184c78c9de8b570"},
-    {file = "rich-9.2.0.tar.gz", hash = "sha256:7003a1cce3b79bf4d34a26099b00a4b67e208d4a6896a1c25368603d5f49f295"},
+    {file = "rich-9.3.0-py3-none-any.whl", hash = "sha256:13cdbb6b72798be9ef30caf460d3949bf057d9f073f73cc853908d50cc31229f"},
+    {file = "rich-9.3.0.tar.gz", hash = "sha256:ca1008c18e91c2d0345764ddb871cc284feadc467241fbb468f14280b791388a"},
 ]
 "ruamel.yaml" = [
     {file = "ruamel.yaml-0.16.12-py2.py3-none-any.whl", hash = "sha256:012b9470a0ea06e4e44e99e7920277edf6b46eee0232a04487ea73a7386340a5"},
@@ -2955,29 +2919,20 @@ rich = [
     {file = "ruamel.yaml.clib-0.2.2-cp27-cp27mu-manylinux1_x86_64.whl", hash = "sha256:73b3d43e04cc4b228fa6fa5d796409ece6fcb53a6c270eb2048109cbcbc3b9c2"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-macosx_10_6_intel.whl", hash = "sha256:53b9dd1abd70e257a6e32f934ebc482dac5edb8c93e23deb663eac724c30b026"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:839dd72545ef7ba78fd2aa1a5dd07b33696adf3e68fae7f31327161c1093001b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-manylinux2014_aarch64.whl", hash = "sha256:1236df55e0f73cd138c0eca074ee086136c3f16a97c2ac719032c050f7e0622f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win32.whl", hash = "sha256:b1e981fe1aff1fd11627f531524826a4dcc1f26c726235a52fcb62ded27d150f"},
     {file = "ruamel.yaml.clib-0.2.2-cp35-cp35m-win_amd64.whl", hash = "sha256:4e52c96ca66de04be42ea2278012a2342d89f5e82b4512fb6fb7134e377e2e62"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-macosx_10_9_x86_64.whl", hash = "sha256:a873e4d4954f865dcb60bdc4914af7eaae48fb56b60ed6daa1d6251c72f5337c"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ab845f1f51f7eb750a78937be9f79baea4a42c7960f5a94dde34e69f3cce1988"},
-    {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:2fd336a5c6415c82e2deb40d08c222087febe0aebe520f4d21910629018ab0f3"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win32.whl", hash = "sha256:e9f7d1d8c26a6a12c23421061f9022bb62704e38211fe375c645485f38df34a2"},
     {file = "ruamel.yaml.clib-0.2.2-cp36-cp36m-win_amd64.whl", hash = "sha256:2602e91bd5c1b874d6f93d3086f9830f3e907c543c7672cf293a97c3fabdcd91"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-macosx_10_9_x86_64.whl", hash = "sha256:44c7b0498c39f27795224438f1a6be6c5352f82cb887bc33d962c3a3acc00df6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:8e8fd0a22c9d92af3a34f91e8a2594eeb35cba90ab643c5e0e643567dc8be43e"},
-    {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:75f0ee6839532e52a3a53f80ce64925ed4aed697dd3fa890c4c918f3304bd4f4"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win32.whl", hash = "sha256:464e66a04e740d754170be5e740657a3b3b6d2bcc567f0c3437879a6e6087ff6"},
     {file = "ruamel.yaml.clib-0.2.2-cp37-cp37m-win_amd64.whl", hash = "sha256:52ae5739e4b5d6317b52f5b040b1b6639e8af68a5b8fd606a8b08658fbd0cab5"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:4df5019e7783d14b79217ad9c56edf1ba7485d614ad5a385d1b3c768635c81c0"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:5254af7d8bdf4d5484c089f929cb7f5bafa59b4f01d4f48adda4be41e6d29f99"},
-    {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:8be05be57dc5c7b4a0b24edcaa2f7275866d9c907725226cdde46da09367d923"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win32.whl", hash = "sha256:74161d827407f4db9072011adcfb825b5258a5ccb3d2cd518dd6c9edea9e30f1"},
     {file = "ruamel.yaml.clib-0.2.2-cp38-cp38-win_amd64.whl", hash = "sha256:058a1cc3df2a8aecc12f983a48bda99315cebf55a3b3a5463e37bb599b05727b"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:c6ac7e45367b1317e56f1461719c853fd6825226f45b835df7436bb04031fd8a"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux1_x86_64.whl", hash = "sha256:b4b0d31f2052b3f9f9b5327024dc629a253a83d8649d4734ca7f35b60ec3e9e5"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:1f8c0a4577c0e6c99d208de5c4d3fd8aceed9574bb154d7a2b21c16bb924154c"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win32.whl", hash = "sha256:46d6d20815064e8bb023ea8628cfb7402c0f0e83de2c2227a88097e239a7dffd"},
-    {file = "ruamel.yaml.clib-0.2.2-cp39-cp39-win_amd64.whl", hash = "sha256:6c0a5dc52fc74eb87c67374a4e554d4761fd42a4d01390b7e868b30d21f4b8bb"},
     {file = "ruamel.yaml.clib-0.2.2.tar.gz", hash = "sha256:2d24bd98af676f4990c4d715bcdc2a60b19c56a3fb3a763164d2d8ca0e806ba7"},
 ]
 scp = [
@@ -3044,8 +2999,8 @@ snowballstemmer = [
     {file = "snowballstemmer-2.0.0.tar.gz", hash = "sha256:df3bac3df4c2c01363f3dd2cfa78cce2840a79b9f1c2d2de9ce8d31683992f52"},
 ]
 stevedore = [
-    {file = "stevedore-3.2.2-py3-none-any.whl", hash = "sha256:5e1ab03eaae06ef6ce23859402de785f08d97780ed774948ef16c4652c41bc62"},
-    {file = "stevedore-3.2.2.tar.gz", hash = "sha256:f845868b3a3a77a2489d226568abe7328b5c2d4f6a011cc759dfa99144a521f0"},
+    {file = "stevedore-3.3.0-py3-none-any.whl", hash = "sha256:50d7b78fbaf0d04cd62411188fa7eedcb03eb7f4c4b37005615ceebe582aa82a"},
+    {file = "stevedore-3.3.0.tar.gz", hash = "sha256:3a5bbd0652bf552748871eaa73a4a8dc2899786bc497a2aa1fcb4dcdb0debeee"},
 ]
 structlog = [
     {file = "structlog-20.1.0-py2.py3-none-any.whl", hash = "sha256:8a672be150547a93d90a7d74229a29e765be05bd156a35cdcc527ebf68e9af92"},
@@ -3062,16 +3017,16 @@ textfsm = [
     {file = "textfsm-1.1.0-py2.py3-none-any.whl", hash = "sha256:0aef3f9cad3d03905915fd62bff358c42b7dc35c863ff2cb0b5324c2b746cc24"},
 ]
 toml = [
-    {file = "toml-0.10.1-py2.py3-none-any.whl", hash = "sha256:bda89d5935c2eac546d648028b9901107a595863cb36bae0c73ac804a9b4ce88"},
-    {file = "toml-0.10.1.tar.gz", hash = "sha256:926b612be1e5ce0634a2ca03470f95169cf16f939018233a670519cb4ac58b0f"},
+    {file = "toml-0.10.2-py2.py3-none-any.whl", hash = "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b"},
+    {file = "toml-0.10.2.tar.gz", hash = "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"},
 ]
 tqdm = [
-    {file = "tqdm-4.51.0-py2.py3-none-any.whl", hash = "sha256:9ad44aaf0fc3697c06f6e05c7cf025dd66bc7bcb7613c66d85f4464c47ac8fad"},
-    {file = "tqdm-4.51.0.tar.gz", hash = "sha256:ef54779f1c09f346b2b5a8e5c61f96fbcb639929e640e59f8cf810794f406432"},
+    {file = "tqdm-4.54.0-py2.py3-none-any.whl", hash = "sha256:9e7b8ab0ecbdbf0595adadd5f0ebbb9e69010e0bd48bbb0c15e550bf2a5292df"},
+    {file = "tqdm-4.54.0.tar.gz", hash = "sha256:5c0d04e06ccc0da1bd3fa5ae4550effcce42fcad947b4a6cafa77bdc9b09ff22"},
 ]
 transitions = [
-    {file = "transitions-0.8.4-py2.py3-none-any.whl", hash = "sha256:1238a081e95ff5aa4a8255dc2ad926cca234695afaf041f9515a2e06d6249f1c"},
-    {file = "transitions-0.8.4.tar.gz", hash = "sha256:9a2841b24789dfd345267cb92e26b79da75fd03f6021d1a5222c71b5c9ae3c16"},
+    {file = "transitions-0.8.5-py2.py3-none-any.whl", hash = "sha256:bb05d3283c91e091046ed5484da2e4f8b489eb5f1bca1a5c76d47d19d703b3ff"},
+    {file = "transitions-0.8.5.tar.gz", hash = "sha256:e441c66a0c753d56c01c3e5e547f21dbe4a5569c939f12477475c5e81d79769b"},
 ]
 typed-ast = [
     {file = "typed_ast-1.4.1-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:73d785a950fc82dd2a25897d525d003f6378d1cb23ab305578394694202a58c3"},
@@ -3102,25 +3057,25 @@ typing-extensions = [
     {file = "typing_extensions-3.7.4.3.tar.gz", hash = "sha256:99d4073b617d30288f569d3f13d2bd7548c3a7e4c8de87db09a9d29bb3a4a60c"},
 ]
 unicon = [
-    {file = "unicon-20.9-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:cab91fc0a4f588146965a7e7556774547300413de8b9469c451d6d4f78ff8bf4"},
-    {file = "unicon-20.9-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:740073536cac550b0c832ba56e3fb9ffa498e4dee40262b4d72c8cd9cd489df9"},
-    {file = "unicon-20.9-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:d45920d3fe56a753e95449234301e55621adfb2476126d53a0bc06c1b70bd4e0"},
-    {file = "unicon-20.9-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:5e18f8ae4f94472c0b8dbd9b0ac994b7ab189cb0527a7337dbea83bb18767853"},
-    {file = "unicon-20.9-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:c66dccffa57eeab5808e31b09c4032349416fe06ff0d2361cb13876da091ffd8"},
-    {file = "unicon-20.9-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:ed0805795cb666d9595245902112c4176fee2e1b40dd374204dbfd3df1aa5d61"},
-    {file = "unicon-20.9-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:cddcf0254a5a52991376e23e9e77e9d2f677042e654dd50484360703f8e49e6b"},
-    {file = "unicon-20.9-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:6bf744bdc620574254999da9a5ab6295fe0484f2c117fb1e68a9b4c6ae922746"},
-    {file = "unicon-20.9-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:7a42c870c5ade0dc3d0f2aab416fb59ec89fe87a1a1775e5553881ce10e966b6"},
-    {file = "unicon-20.9-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:b0d691ebe0af032b06ccd32771bc306cef2f098b5b9c607599f34ffb843f2fab"},
-    {file = "unicon-20.9-cp38-cp38-manylinux1_i686.whl", hash = "sha256:d6a1cb33e524efdf1650fa13077812e899f48cdf3a1ff3377ca125856da57697"},
-    {file = "unicon-20.9-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:48feb7a2c129653e9092302ef263fb354208e1e3cc45febcb33c719cde2a783b"},
+    {file = "unicon-20.10-cp35-cp35m-macosx_10_10_x86_64.whl", hash = "sha256:daa2df86cc90e2c9b06368eea4954ab7a96b1af4890e46b82eeab570de4fbbb1"},
+    {file = "unicon-20.10-cp35-cp35m-manylinux1_i686.whl", hash = "sha256:019ba2c25a5306719eca3ede79826ad69f5e84af6d57df7e806eebb128b888f1"},
+    {file = "unicon-20.10-cp35-cp35m-manylinux1_x86_64.whl", hash = "sha256:8320dea6e75ae5361f6b810d06d70d79d8fd3a09be9054f11129e06557482ea3"},
+    {file = "unicon-20.10-cp36-cp36m-macosx_10_10_x86_64.whl", hash = "sha256:0ee8b28e41f57600f2f4e649839941c88d8c0dd9a4456b54532e868c74639b0a"},
+    {file = "unicon-20.10-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:9f93fd3eeeb7a8d0f06f11640a78f5cb9239bde4c9d19865dae9b161e64bdde4"},
+    {file = "unicon-20.10-cp36-cp36m-manylinux1_x86_64.whl", hash = "sha256:25e2ed4b5b86b2b338a58d6d549d79c56973f902c9bf087379d6f0f1696c7f2c"},
+    {file = "unicon-20.10-cp37-cp37m-macosx_10_10_x86_64.whl", hash = "sha256:2cdb6c3275b94912e03127ac3b83525c560f37e24fb506bc40e239fe4e32ae5d"},
+    {file = "unicon-20.10-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:43e814216aa52bd74a818e2a25a61dfe82048efc49b8c7999673bba6028e542c"},
+    {file = "unicon-20.10-cp37-cp37m-manylinux1_x86_64.whl", hash = "sha256:9663eb771b9b1a5207fa108925044da81e0ef198f8dc620fdf9401c499499fd0"},
+    {file = "unicon-20.10-cp38-cp38-macosx_10_10_x86_64.whl", hash = "sha256:eb2c1bb4e1a9ecbb9330a2eb5244f5279ff839d1c86763eeed5bcadaf5fb9f15"},
+    {file = "unicon-20.10-cp38-cp38-manylinux1_i686.whl", hash = "sha256:1e49149709cfdf7bb72f08aff020e29c688a774eb5342b0bbae01611bf069ef0"},
+    {file = "unicon-20.10-cp38-cp38-manylinux1_x86_64.whl", hash = "sha256:4129d870b0cdf6de8e1effafffe79d4aa50a2550122130791592fac237044530"},
 ]
 "unicon.plugins" = [
-    {file = "unicon.plugins-20.9-py3-none-any.whl", hash = "sha256:a82710b37efd8171ee282bf4a598b1ed741e8ec266d4637ffa4a0a9daada80df"},
+    {file = "unicon.plugins-20.10-py3-none-any.whl", hash = "sha256:a0e491627d5df7ce3f5b7997e5e06db281408f018431944369234563b1103a84"},
 ]
 urllib3 = [
-    {file = "urllib3-1.25.11-py2.py3-none-any.whl", hash = "sha256:f5321fbe4bf3fefa0efd0bfe7fb14e90909eb62a48ccda331726b4319897dd5e"},
-    {file = "urllib3-1.25.11.tar.gz", hash = "sha256:8d7eaa5a82a1cac232164990f04874c594c9453ec55eef02eab885aa02fc17a2"},
+    {file = "urllib3-1.26.2-py2.py3-none-any.whl", hash = "sha256:d8ff90d979214d7b4f8ce956e80f4028fc6860e4431f731ea4a8c08f23f99473"},
+    {file = "urllib3-1.26.2.tar.gz", hash = "sha256:19188f96923873c92ccb987120ec4acaa12f0461fa9ce5d3d0772bc965a39e08"},
 ]
 wcwidth = [
     {file = "wcwidth-0.2.5-py2.py3-none-any.whl", hash = "sha256:beb4802a9cebb9144e99086eff703a642a13d6a0052920003a230f3294bbe784"},
@@ -3144,39 +3099,43 @@ yamlordereddictloader = [
     {file = "yamlordereddictloader-0.4.0.tar.gz", hash = "sha256:7f30f0b99ea3f877f7cb340c570921fa9d639b7f69cba18be051e27f8de2080e"},
 ]
 yarl = [
-    {file = "yarl-1.6.2-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:d77f6c9133d2aabb290a7846aaa74ec14d7b5ab35b01591fac5a70c4a8c959a2"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:311effab3b3828ab34f0e661bb57ff422f67d5c33056298bda4c12195251f8dd"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:f835015a825980b65356e9520979a1564c56efea7da7d4b68a14d4a07a3a7336"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:59f78b5da34ddcffb663b772f7619e296518712e022e57fc5d9f921818e2ab7c"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:3526cb5905907f0e42bee7ef57ae4a5f02bc27dcac27859269e2bba0caa4c2b6"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:e77bf79ad1ccae672eab22453838382fe9029fc27c8029e84913855512a587d8"},
-    {file = "yarl-1.6.2-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:b3dd1052afd436ba737e61f5d3bed1f43a7f9a33fc58fbe4226eb919a7006019"},
-    {file = "yarl-1.6.2-cp36-cp36m-win_amd64.whl", hash = "sha256:6f29115b0c330da25a04f48612d75333bca04521181a666ca0b8761005a99150"},
-    {file = "yarl-1.6.2-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:f3031c78edf10315abe232254e6a36b65afe65fded41ee54ed7976d0b2cdf0da"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:4bed5cd7c8e69551eb19df15295ba90e62b9a6a1149c76eb4a9bab194402a156"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:39b1e586f34b1d2512c9b39aa3cf24c870c972d525e36edc9ee19065db4737bb"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:03b7a44384ad60be1b7be93c2a24dc74895f8d767ea0bce15b2f6fc7695a3843"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:a1fd575dd058e10ad4c35065e7c3007cc74d142f622b14e168d8a273a2fa8713"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:9b48d31f8d881713fd461abfe7acbb4dcfeb47cec3056aa83f2fbcd2244577f7"},
-    {file = "yarl-1.6.2-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:1c05ae3d5ea4287470046a2c2754f0a4c171b84ea72c8a691f776eb1753dfb91"},
-    {file = "yarl-1.6.2-cp37-cp37m-win_amd64.whl", hash = "sha256:f4f27ff3dd80bc7c402def211a47291ea123d59a23f59fe18fc0e81e3e71f385"},
-    {file = "yarl-1.6.2-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:73d4e1e1ef5e52d526c92f07d16329e1678612c6a81dd8101fdcae11a72de15c"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux1_i686.whl", hash = "sha256:db643ce2b58a4bd11a82348225c53c76ecdd82bb37cf4c085e6df1b676f4038c"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:d25d3311794e6c71b608d7c47651c8f65eea5ab15358a27f29330b3475e8f8e5"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:51c6d3cf7a1f1fbe134bb92f33b7affd94d6de24cd64b466eb12de52120fb8c6"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:cd623170c729a865037828e3f99f8ebdb22a467177a539680dfc5670b74c84e2"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:c056e86bff5a0b566e0d9fab4f67e83b12ae9cbcd250d334cbe2005bbe8c96f2"},
-    {file = "yarl-1.6.2-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:f4c007156732866aa4507d619fe6f8f2748caabed4f66b276ccd97c82572620c"},
-    {file = "yarl-1.6.2-cp38-cp38-win_amd64.whl", hash = "sha256:2bb2e21cf062dfbe985c3cd4618bae9f25271efcad9e7be1277861247eee9839"},
-    {file = "yarl-1.6.2-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:b99c25ed5c355b35d1e6dae87ac7297a4844a57dc5766b173b88b6163a36eb0d"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux1_i686.whl", hash = "sha256:2467baf8233f7c64048df37e11879c553943ffe7f373e689711ec2807ea13805"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:e3a0c43a26dfed955b2a06fdc4d51d2c51bc2200aff8ce8faf14e676ea8c8862"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:f2f0174cb15435957d3b751093f89aede77df59a499ab7516bbb633b77ead13a"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:d695439c201ed340745250f9eb4dfe8d32bf1e680c16477107b8f3ce4bff4fdb"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:f57744fc61e118b5d114ae8077d8eb9df4d2d2c11e2af194e21f0c11ed9dcf6c"},
-    {file = "yarl-1.6.2-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:d894a2442d2cd20a3b0b0dce5a353d316c57d25a2b445e03f7eac90eee27b8af"},
-    {file = "yarl-1.6.2-cp39-cp39-win_amd64.whl", hash = "sha256:076157404db9db4bb3fa9db22db319bbb36d075eeab19ba018ce20ae0cacf037"},
-    {file = "yarl-1.6.2.tar.gz", hash = "sha256:c45b49b59a5724869899798e1bbd447ac486215269511d3b76b4c235a1b766b6"},
+    {file = "yarl-1.6.3-cp36-cp36m-macosx_10_14_x86_64.whl", hash = "sha256:0355a701b3998dcd832d0dc47cc5dedf3874f966ac7f870e0f3a6788d802d434"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux1_i686.whl", hash = "sha256:bafb450deef6861815ed579c7a6113a879a6ef58aed4c3a4be54400ae8871478"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_aarch64.whl", hash = "sha256:547f7665ad50fa8563150ed079f8e805e63dd85def6674c97efd78eed6c224a6"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_i686.whl", hash = "sha256:63f90b20ca654b3ecc7a8d62c03ffa46999595f0167d6450fa8383bab252987e"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_ppc64le.whl", hash = "sha256:97b5bdc450d63c3ba30a127d018b866ea94e65655efaf889ebeabc20f7d12406"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_s390x.whl", hash = "sha256:d8d07d102f17b68966e2de0e07bfd6e139c7c02ef06d3a0f8d2f0f055e13bb76"},
+    {file = "yarl-1.6.3-cp36-cp36m-manylinux2014_x86_64.whl", hash = "sha256:15263c3b0b47968c1d90daa89f21fcc889bb4b1aac5555580d74565de6836366"},
+    {file = "yarl-1.6.3-cp36-cp36m-win32.whl", hash = "sha256:b5dfc9a40c198334f4f3f55880ecf910adebdcb2a0b9a9c23c9345faa9185721"},
+    {file = "yarl-1.6.3-cp36-cp36m-win_amd64.whl", hash = "sha256:b2e9a456c121e26d13c29251f8267541bd75e6a1ccf9e859179701c36a078643"},
+    {file = "yarl-1.6.3-cp37-cp37m-macosx_10_14_x86_64.whl", hash = "sha256:ce3beb46a72d9f2190f9e1027886bfc513702d748047b548b05dab7dfb584d2e"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux1_i686.whl", hash = "sha256:2ce4c621d21326a4a5500c25031e102af589edb50c09b321049e388b3934eec3"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_aarch64.whl", hash = "sha256:d26608cf178efb8faa5ff0f2d2e77c208f471c5a3709e577a7b3fd0445703ac8"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_i686.whl", hash = "sha256:4c5bcfc3ed226bf6419f7a33982fb4b8ec2e45785a0561eb99274ebbf09fdd6a"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_ppc64le.whl", hash = "sha256:4736eaee5626db8d9cda9eb5282028cc834e2aeb194e0d8b50217d707e98bb5c"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_s390x.whl", hash = "sha256:68dc568889b1c13f1e4745c96b931cc94fdd0defe92a72c2b8ce01091b22e35f"},
+    {file = "yarl-1.6.3-cp37-cp37m-manylinux2014_x86_64.whl", hash = "sha256:7356644cbed76119d0b6bd32ffba704d30d747e0c217109d7979a7bc36c4d970"},
+    {file = "yarl-1.6.3-cp37-cp37m-win32.whl", hash = "sha256:00d7ad91b6583602eb9c1d085a2cf281ada267e9a197e8b7cae487dadbfa293e"},
+    {file = "yarl-1.6.3-cp37-cp37m-win_amd64.whl", hash = "sha256:69ee97c71fee1f63d04c945f56d5d726483c4762845400a6795a3b75d56b6c50"},
+    {file = "yarl-1.6.3-cp38-cp38-macosx_10_14_x86_64.whl", hash = "sha256:e46fba844f4895b36f4c398c5af062a9808d1f26b2999c58909517384d5deda2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux1_i686.whl", hash = "sha256:31ede6e8c4329fb81c86706ba8f6bf661a924b53ba191b27aa5fcee5714d18ec"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_aarch64.whl", hash = "sha256:fcbb48a93e8699eae920f8d92f7160c03567b421bc17362a9ffbbd706a816f71"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_i686.whl", hash = "sha256:72a660bdd24497e3e84f5519e57a9ee9220b6f3ac4d45056961bf22838ce20cc"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_ppc64le.whl", hash = "sha256:324ba3d3c6fee56e2e0b0d09bf5c73824b9f08234339d2b788af65e60040c959"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_s390x.whl", hash = "sha256:e6b5460dc5ad42ad2b36cca524491dfcaffbfd9c8df50508bddc354e787b8dc2"},
+    {file = "yarl-1.6.3-cp38-cp38-manylinux2014_x86_64.whl", hash = "sha256:6d6283d8e0631b617edf0fd726353cb76630b83a089a40933043894e7f6721e2"},
+    {file = "yarl-1.6.3-cp38-cp38-win32.whl", hash = "sha256:9ede61b0854e267fd565e7527e2f2eb3ef8858b301319be0604177690e1a3896"},
+    {file = "yarl-1.6.3-cp38-cp38-win_amd64.whl", hash = "sha256:f0b059678fd549c66b89bed03efcabb009075bd131c248ecdf087bdb6faba24a"},
+    {file = "yarl-1.6.3-cp39-cp39-macosx_10_14_x86_64.whl", hash = "sha256:329412812ecfc94a57cd37c9d547579510a9e83c516bc069470db5f75684629e"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux1_i686.whl", hash = "sha256:c49ff66d479d38ab863c50f7bb27dee97c6627c5fe60697de15529da9c3de724"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_aarch64.whl", hash = "sha256:f040bcc6725c821a4c0665f3aa96a4d0805a7aaf2caf266d256b8ed71b9f041c"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_i686.whl", hash = "sha256:d5c32c82990e4ac4d8150fd7652b972216b204de4e83a122546dce571c1bdf25"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_ppc64le.whl", hash = "sha256:d597767fcd2c3dc49d6eea360c458b65643d1e4dbed91361cf5e36e53c1f8c96"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_s390x.whl", hash = "sha256:8aa3decd5e0e852dc68335abf5478a518b41bf2ab2f330fe44916399efedfae0"},
+    {file = "yarl-1.6.3-cp39-cp39-manylinux2014_x86_64.whl", hash = "sha256:73494d5b71099ae8cb8754f1df131c11d433b387efab7b51849e7e1e851f07a4"},
+    {file = "yarl-1.6.3-cp39-cp39-win32.whl", hash = "sha256:5b883e458058f8d6099e4420f0cc2567989032b5f34b271c0827de9f1079a424"},
+    {file = "yarl-1.6.3-cp39-cp39-win_amd64.whl", hash = "sha256:4953fb0b4fdb7e08b2f3b3be80a00d28c5c8a2056bb066169de00e6501b986b6"},
+    {file = "yarl-1.6.3.tar.gz", hash = "sha256:8a9066529240171b68893d60dca86a763eae2139dd42f42106b03cf4b426bf10"},
 ]
 zipp = [
     {file = "zipp-3.4.0-py3-none-any.whl", hash = "sha256:102c24ef8f171fd729d46599845e95c7ab894a4cf45f5de11a44cc7444fb1108"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,20 +11,18 @@ packages = [
 [tool.poetry.dependencies]
 python = "^3.7"
 pynetbox = "^5.0"
-jsonschema = {version = "^3.2.0" }
-toml = {version = "^0.10.0" }
+toml = "^0.10"
 nornir = "^2.4"
 termcolor = "^1.1"
 click = "^7.1.1"
 pydantic = "^1.6.1"
 pybatfish = "^2020.8.11"
-"genie.metaparser" = "^19.12"
 genie = "^20.9"
 pyats = "^20.9"
 netmiko = "^3.3.2"
 ntc-templates = "^1.6.0"
 structlog = "^20.1.0"
-diffsync = "^1.0.0"
+diffsync = "~1.0.0"
 rich = "^9.2.0"
 
 [tool.poetry.dev-dependencies]


### PR DESCRIPTION
- Remove unused dependencies : genie.metaparser, jsonschema
- Lock diffsync to 1.0.0 since there are some breaking changes in 1.1.0
- Update all dependencies 