### PR TITLE
Fix issue with Vlan and Interface adapter 

### DIFF
--- a/network_importer/adapters/netbox_api/models.py
+++ b/network_importer/adapters/netbox_api/models.py
@@ -103,6 +103,9 @@ class NetboxInterface(Interface):
                     resp.append(nid)
             return resp
 
+        complete_attrs = self.get_attrs()
+        complete_attrs.update(attrs)
+        attrs = complete_attrs
         nb_params = {}
 
         # Identify the id of the device this interface is attached to
@@ -521,7 +524,7 @@ class NetboxVlan(Vlan):
 
         if "name" in attrs and attrs["name"]:
             nb_params["name"] = attrs["name"]
-        else:
+        elif not self.name:
             nb_params["name"] = f"vlan-{self.vid}"
 
         site = self.diffsync.get(self.diffsync.site, identifier=self.site_name)
@@ -658,7 +661,7 @@ class NetboxVlanPre29(NetboxVlan):
 
         if "name" in attrs and attrs["name"]:
             nb_params["name"] = attrs["name"]
-        else:
+        elif not self.name:
             nb_params["name"] = f"vlan-{self.vid}"
 
         site = self.diffsync.get(self.diffsync.site, identifier=self.site_name)
@@ -697,7 +700,7 @@ class NetboxVlanPre29(NetboxVlan):
         return item
 
     def update_clean_tags(self, nb_params, obj):
-        """Update list of vlan tags with additinal tags that already exists on the object in netbox.
+        """Update list of vlan tags with additional tags that already exists on the object in netbox.
 
         Args:
             nb_params (dict): dict of parameters in netbox format

--- a/network_importer/adapters/netbox_api/models.py
+++ b/network_importer/adapters/netbox_api/models.py
@@ -103,9 +103,11 @@ class NetboxInterface(Interface):
                     resp.append(nid)
             return resp
 
+        # Reconstruct all attrs of the object in its expected state
         complete_attrs = self.get_attrs()
         complete_attrs.update(attrs)
         attrs = complete_attrs
+
         nb_params = {}
 
         # Identify the id of the device this interface is attached to

--- a/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
@@ -62,12 +62,12 @@ def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
 
     params = intf.translate_attrs_for_netbox({})
 
-    assert "name" in params
+    assert sorted(list(params.keys())) == ["description", "device", "lag", "name", "type"]
     assert params["name"] == "ge-0/0/0"
-    assert "device" in params
     assert params["device"] == 29
     assert params["type"] == "other"
-    assert sorted(list(params.keys())) == ["device", "name", "type"]
+    assert params["lag"] == None
+    assert params["description"] == ""
 
 
 def test_translate_attrs_for_netbox_type(netbox_api_base):
@@ -97,7 +97,8 @@ def test_translate_attrs_for_netbox_description(netbox_api_base):
 
     params = intf.translate_attrs_for_netbox({})
     assert_baseline
-    assert "description" not in params
+    assert "description" in params
+    assert params["description"] == ""
 
     params = intf.translate_attrs_for_netbox({"description": "my_description"})
     assert_baseline
@@ -158,7 +159,7 @@ def test_translate_attrs_for_netbox_vlan(netbox_api_base):
     params = intf.translate_attrs_for_netbox({"switchport_mode": "ACCESS", "mode": "ACCESS"})
     assert_baseline
     assert params["mode"] == "access"
-    assert "untagged_vlan" not in params
+    assert params["untagged_vlan"] is None
 
     params = intf.translate_attrs_for_netbox(
         {"switchport_mode": "TRUNK", "mode": "TRUNK", "allowed_vlans": ["HQ__111", "HQ__100"]}

--- a/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
@@ -66,7 +66,7 @@ def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
     assert params["name"] == "ge-0/0/0"
     assert params["device"] == 29
     assert params["type"] == "other"
-    assert params["lag"] == None
+    assert params["lag"] is None
     assert params["description"] == ""
 
 

--- a/tests/unit/adapters/netbox_api/models/test_netbox_vlan.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_vlan.py
@@ -77,6 +77,22 @@ def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
     assert "tags" not in params
 
 
+def test_translate_attrs_for_netbox_with_partial_attrs(netbox_api_base):
+
+    vlan = NetboxVlan(vid=100, name="MYVLAN", site_name="HQ", remote_id=30)
+    netbox_api_base.add(vlan)
+
+    netbox_api_base.add(NetboxDevice(name="dev1", site_name="HQ", remote_id=32, device_tag_id=12))
+    netbox_api_base.add(NetboxDevice(name="dev2", site_name="HQ", remote_id=33, device_tag_id=13))
+    params = vlan.translate_attrs_for_netbox({"associated_devices": ["dev1", "dev2"]})
+
+    assert "name" not in params
+    assert "site" in params
+    assert params["site"] == 10
+    assert "tags" in params
+    assert sorted(params["tags"]) == [12, 13]
+
+
 def test_translate_attrs_for_netbox_with_attrs(netbox_api_base):
 
     vlan = NetboxVlan(vid=100, site_name="HQ", remote_id=30)

--- a/tests/unit/adapters/netbox_api/models/test_netbox_vlan_pre29.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_vlan_pre29.py
@@ -77,6 +77,20 @@ def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
     assert "tags" not in params
 
 
+def test_translate_attrs_for_netbox_with_partial_attrs(netbox_api_base):
+
+    vlan = NetboxVlanPre29(vid=100, name="MYVLAN", site_name="HQ", remote_id=30)
+    netbox_api_base.add(vlan)
+
+    params = vlan.translate_attrs_for_netbox({"associated_devices": ["dev1", "dev2"]})
+
+    assert "name" not in params
+    assert "site" in params
+    assert params["site"] == 10
+    assert "tags" in params
+    assert params["tags"] == ["device=dev1", "device=dev2"]
+
+
 def test_translate_attrs_for_netbox_with_attrs(netbox_api_base):
 
     vlan = NetboxVlanPre29(vid=100, site_name="HQ", remote_id=30)


### PR DESCRIPTION
Originally DiffSync was passing the entire object in attrs when calling update() and so the function`translate_attrs_for_netbox` for NetboxVlan and NetboxInterface were expecting all attrs to be present everytime.

This PR fixes both `translate_attrs_for_netbox` to work with partial payload. 
- For NetboxInterface, the solution was to recreate a complete payload 
- For NetboxVlan since the payload is smaller and we need to manage the tags, the fix was just to ensure that we won't redefine the name of the vlan if the name is not present

