### PR TITLE
Refactor build_inventory to use build_filter_params

### DIFF
--- a/network_importer/cli.py
+++ b/network_importer/cli.py
@@ -26,7 +26,6 @@ from rich.console import Console
 from rich.table import Table
 
 import network_importer.config as config
-from network_importer.utils import build_filter_params
 from network_importer.main import NetworkImporter
 
 import network_importer.performance as perf

--- a/network_importer/cli.py
+++ b/network_importer/cli.py
@@ -72,9 +72,6 @@ def init(config_file):
     # Disable logging in console for DiffSync
     enable_console_logging(verbosity=0)
 
-    filters = {}
-    build_filter_params(config.SETTINGS.inventory.filter.split((",")), filters)
-
     ni = NetworkImporter()
     return ni
 

--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -52,7 +52,6 @@ class NetworkImporter:
     @timeit
     def build_inventory(self, limit=None):
         """Build the inventory for the Network Importer in Nornir format."""
-
         # Filters can be defined at the configuration level or in CLI or both
         params = {}
         build_filter_params(config.SETTINGS.inventory.filter.split((",")), params)

--- a/network_importer/utils.py
+++ b/network_importer/utils.py
@@ -211,7 +211,7 @@ def build_filter_params(filter_params, params):
     """Update params dict() with filter args in required format for pynetbox.
 
     Args:
-      filter_params (str): split string from cli or config
+      filter_params (list): split string from cli or config
       params (dict): object to hold params
     """
     for param_value in filter_params:

--- a/tests/unit/test_utils.py
+++ b/tests/unit/test_utils.py
@@ -18,6 +18,7 @@ from network_importer.utils import (
     is_interface_physical,
     is_interface_lag,
     is_mac_address,
+    build_filter_params,
 )
 
 
@@ -99,3 +100,34 @@ def test_is_mac_address():
     assert is_mac_address("F8f2.1e89.3c") is False
     assert is_mac_address("F8f2.1e89.3c66.67") is False
     assert is_mac_address("not a mac address") is False
+
+
+def test_build_filter_params():
+
+    # base implementation
+    params = {}
+    build_filter_params(["site=nyc", "device=dev"], params)
+    assert params == {"device": "dev", "site": "nyc"}
+
+    params = {}
+    build_filter_params(["device=dev"], params)
+    assert params == {"device": "dev"}
+
+    # multiple filter of the same type
+    params = {}
+    build_filter_params(["site=nyc", "site=jcy"], params)
+    assert params == {"site": ["nyc", "jcy"]}
+
+    params = {}
+    build_filter_params(["device=dev"], params)
+    assert params == {"device": "dev"}
+
+    # Existing keys in params should be preserved
+    params = {"site": "jcy"}
+    build_filter_params(["site=nyc", "device=dev"], params)
+    assert params == {"device": "dev", "site": ["jcy", "nyc"]}
+
+    # Invalid string (no =) will be ignored
+    params = {"site": "jcy"}
+    build_filter_params(["site", "device=dev"], params)
+    assert params == {"device": "dev", "site": "jcy"}


### PR DESCRIPTION
Fixes #156

Looks like we had a function already written to properly parse the limit/filter for the inventory but strangely the code wasn't using it.
This PR refactor `build_inventory` to leverage  `build_filter_params` and adds some unit tests for `build_filter_params`