### PR TITLE
Resolve VLAN detection and population for Network

### DIFF
--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -229,7 +229,7 @@ class NetworkImporterAdapter(BaseAdapter):
             if intf["Encapsulation_VLAN"]:
                 interface.mode = "L3_SUB_VLAN"
                 vlan = self.vlan(vid=intf["Encapsulation_VLAN"], site_name=site.name)
-                vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan, site)
                 if import_vlans:
                     interface.allowed_vlans = [vlan.get_unique_id()]
             else:
@@ -240,7 +240,7 @@ class NetworkImporterAdapter(BaseAdapter):
             for vid in vids:
                 vlan = self.vlan(vid=vid, site_name=site.name)
                 if create_vlans:
-                    vlan, _ = self.get_or_create_vlan(vlan)
+                    vlan, _ = self.get_or_create_vlan(vlan, site)
                 if import_vlans:
                     interface.allowed_vlans.append(vlan.get_unique_id())
 
@@ -254,7 +254,7 @@ class NetworkImporterAdapter(BaseAdapter):
         elif interface.mode == "ACCESS" and intf["Access_VLAN"]:
             vlan = self.vlan(vid=intf["Access_VLAN"], site_name=site.name)
             if create_vlans:
-                vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan, site)
             if import_vlans:
                 interface.access_vlan = vlan.get_unique_id()
 

--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -229,8 +229,7 @@ class NetworkImporterAdapter(BaseAdapter):
             if intf["Encapsulation_VLAN"]:
                 interface.mode = "L3_SUB_VLAN"
                 vlan = self.vlan(vid=intf["Encapsulation_VLAN"], site_name=site.name)
-                if create_vlans:
-                    vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan)
                 if import_vlans:
                     interface.allowed_vlans = [vlan.get_unique_id()]
             else:


### PR DESCRIPTION
This PR fixes (Network side):
* L3 sub interface VLANs not being correct recognized.
* VLANs not being added to the site model (network importer) resulting in the VLAN differential results being incorrect.
