### PR TITLE
Fix Interface and Prefix VLAN Associations

### DIFF
--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -229,7 +229,7 @@ class NetworkImporterAdapter(BaseAdapter):
             if intf["Encapsulation_VLAN"]:
                 interface.mode = "L3_SUB_VLAN"
                 vlan = self.vlan(vid=intf["Encapsulation_VLAN"], site_name=site.name)
-                vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan, site)
                 if import_vlans:
                     interface.allowed_vlans = [vlan.get_unique_id()]
             else:
@@ -240,7 +240,7 @@ class NetworkImporterAdapter(BaseAdapter):
             for vid in vids:
                 vlan = self.vlan(vid=vid, site_name=site.name)
                 if create_vlans:
-                    vlan, _ = self.get_or_create_vlan(vlan)
+                    vlan, _ = self.get_or_create_vlan(vlan, site)
                 if import_vlans:
                     interface.allowed_vlans.append(vlan.get_unique_id())
 
@@ -254,7 +254,7 @@ class NetworkImporterAdapter(BaseAdapter):
         elif interface.mode == "ACCESS" and intf["Access_VLAN"]:
             vlan = self.vlan(vid=intf["Access_VLAN"], site_name=site.name)
             if create_vlans:
-                vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan, site)
             if import_vlans:
                 interface.access_vlan = vlan.get_unique_id()
 

--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -232,6 +232,7 @@ class NetworkImporterAdapter(BaseAdapter):
                 vlan, _ = self.get_or_create_vlan(vlan, site)
                 if import_vlans:
                     interface.allowed_vlans = [vlan.get_unique_id()]
+                    interface_vlans = interface.allowed_vlans
             else:
                 interface.mode = interface.switchport_mode
 
@@ -244,12 +245,15 @@ class NetworkImporterAdapter(BaseAdapter):
                 if import_vlans:
                     interface.allowed_vlans.append(vlan.get_unique_id())
 
+            interface_vlans = interface.allowed_vlans
+
             if intf["Native_VLAN"]:
                 native_vlan = self.vlan(vid=intf["Native_VLAN"], site_name=site.name)
                 if create_vlans:
                     native_vlan, _ = self.get_or_create_vlan(native_vlan)
                 if import_vlans:
                     interface.access_vlan = native_vlan.get_unique_id()
+                    interface_vlans = [interface.access_vlan]
 
         elif interface.mode == "ACCESS" and intf["Access_VLAN"]:
             vlan = self.vlan(vid=intf["Access_VLAN"], site_name=site.name)
@@ -257,6 +261,7 @@ class NetworkImporterAdapter(BaseAdapter):
                 vlan, _ = self.get_or_create_vlan(vlan, site)
             if import_vlans:
                 interface.access_vlan = vlan.get_unique_id()
+                interface_vlans = [interface.access_vlan]
 
         if interface.is_lag is False and interface.is_lag_member is None and intf["Channel_Group"]:
             interface.parent = self.interface(name=intf["Channel_Group"], device_name=device.name).get_unique_id()

--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -229,8 +229,7 @@ class NetworkImporterAdapter(BaseAdapter):
             if intf["Encapsulation_VLAN"]:
                 interface.mode = "L3_SUB_VLAN"
                 vlan = self.vlan(vid=intf["Encapsulation_VLAN"], site_name=site.name)
-                if create_vlans:
-                    vlan, _ = self.get_or_create_vlan(vlan)
+                vlan, _ = self.get_or_create_vlan(vlan)
                 if import_vlans:
                     interface.allowed_vlans = [vlan.get_unique_id()]
             else:

--- a/tests/unit/adapters/network_importer/test_load_batfish_interface.py
+++ b/tests/unit/adapters/network_importer/test_load_batfish_interface.py
@@ -154,7 +154,8 @@ def test_load_batfish_interface_intf_ether_sub(network_importer_base, site_sfo, 
     assert not intf.is_lag_member
     assert intf.allowed_vlans == ["sfo__201"]
 
-    assert "sfo__201" in adapter._data['vlan']
+    assert "sfo__201" in adapter._data["vlan"]  # pylint: disable=W0212
+
 
 def test_load_batfish_interface_intf_lag_member(network_importer_base, site_sfo, dev_spine1):
 

--- a/tests/unit/adapters/network_importer/test_load_batfish_interface.py
+++ b/tests/unit/adapters/network_importer/test_load_batfish_interface.py
@@ -154,6 +154,7 @@ def test_load_batfish_interface_intf_ether_sub(network_importer_base, site_sfo, 
     assert not intf.is_lag_member
     assert intf.allowed_vlans == ["sfo__201"]
 
+    assert "sfo__201" in adapter._data['vlan']
 
 def test_load_batfish_interface_intf_lag_member(network_importer_base, site_sfo, dev_spine1):
 


### PR DESCRIPTION
This PR fixes:
* the population of the VLAN attribute within the Prefix model, in other words Prefix to VLAN association. As a result resolves issues with prefix imports. 
* L3 sub interface VLANs not being correct recognized. To provide some additional context the L3 sub interface is different to Trunks and Access ports, in that it doesn't need the assigned VLAN to be created in a VLAN DB for the interface to correctly tag/pass the packet. Due to this the standard methods in Network Importer for VLAN population are negated and the VLAN is directly added based on what is assigned to the interface. Ref: https://github.com/networktocode/network-importer/pull/180/files#diff-382d3f228f51185a2f8caabe64eb775b0a22b475b2ad3a72b2a9df25eeb3c6afL232
*  VLANs not being added to the site model (network importer) resulting in the VLAN differential results being incorrect.