### PR TITLE
Catch exception due to duplicate IPs

### DIFF
--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -305,7 +305,10 @@ class NetBoxAPIAdapter(BaseAdapter):
             interface = self.get(
                 self.interface, identifier=dict(device_name=device.name, name=ip_address.interface_name)
             )
-            interface.add_child(ip_address)
+            try:
+                interface.add_child(ip_address)
+            except ObjectAlreadyExists:
+                LOGGER.error("%s | Duplicate IP found for %s (%s) ; IP already imported.", self.name, ip_address, device.name)
 
         LOGGER.debug("%s | Found %s ip addresses for %s", self.name, len(ips), device.name)
 


### PR DESCRIPTION
In the event of a duplicate IP being detected Network Importer will raise an exception due to being unable to add it to the diffsync model as it is already present. This PR catches the exception, logs the details and allows Network Importer to proceed.