### PR TITLE
Resolve sync issue when device is not accessible

### DIFF
--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -18,6 +18,8 @@ import sys
 import warnings
 import importlib
 
+from diffsync.enum import DiffSyncFlags
+
 import network_importer.config as config
 from network_importer.exceptions import AdapterLoadFatalError
 from network_importer.utils import patch_http_connection_pool, build_filter_params
@@ -27,7 +29,6 @@ from network_importer.diff import NetworkImporterDiff
 from network_importer.tasks import check_if_reachable, warning_not_reachable
 from network_importer.performance import timeit
 from network_importer.inventory import reachable_devs
-from diffsync.enum import DiffSyncFlags
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 

--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -27,6 +27,7 @@ from network_importer.diff import NetworkImporterDiff
 from network_importer.tasks import check_if_reachable, warning_not_reachable
 from network_importer.performance import timeit
 from network_importer.inventory import reachable_devs
+from diffsync.enum import DiffSyncFlags
 
 warnings.filterwarnings("ignore", category=DeprecationWarning)
 
@@ -142,7 +143,7 @@ class NetworkImporter:
 
     def sync(self):
         """Synchronize the SOT adapter and the network adapter."""
-        self.sot.sync_from(self.network, diff_class=NetworkImporterDiff)
+        self.sot.sync_from(self.network, diff_class=NetworkImporterDiff, flags=DiffSyncFlags.SKIP_UNMATCHED_DST)
 
     def diff(self):
         """Generate a diff of the SOT adapter and the network adapter."""


### PR DESCRIPTION
This PR resolves the issue of sync failures when a device is not added to the `network` model.
```
File "/opt/rick/venv/network-importer-XsxMQK7s-py3.6/lib/python3.6/site-packages/diffsync/__init__.py", line 567, in get
    raise ObjectNotFound(f"{modelname} {uid} not present in {self.name}")
diffsync.exceptions.ObjectNotFound: device rtr001 not present in Netbox
```
In some situations the device may not be added to the `network` model i.e. due to the being unreachable or the hostname being incorrect upon the device. This will result in the device being present in the `sot` model and not the `network` model. At the point of sync the device is removed from the `sot` model, but the child objects cannot be updated because the parent device object is not present. This update resolves this by ensuring that we:
> Ignore objects that only exist in the target/"to" DiffSync when determining diffs and syncing.
> ... no objects will be deleted from the target/"to" DiffSync [1]

[1] https://github.com/networktocode/diffsync/blob/269df51ce248beaef17d72374e96d19e6df95a13/diffsync/enum.py#L53