### PR TITLE
Add support for duplicate ip addresses

### DIFF
--- a/examples/multi_site_02/configs/configs/nyc-spine-01.conf
+++ b/examples/multi_site_02/configs/configs/nyc-spine-01.conf
@@ -73,6 +73,10 @@ interface Ethernet1/3
   no shutdown
 
 interface Ethernet1/4
+  description duplicate_ip_not_connected
+  no switchport
+  ip address 10.255.0.38/30
+  no shutdown
 
 interface Ethernet1/5
 

--- a/examples/multi_site_02/configs/configs/nyc-spine-01.conf
+++ b/examples/multi_site_02/configs/configs/nyc-spine-01.conf
@@ -75,10 +75,14 @@ interface Ethernet1/3
 interface Ethernet1/4
   description duplicate_ip_not_connected
   no switchport
-  ip address 10.255.0.38/30
+  ip address 10.200.0.1/32
   no shutdown
 
 interface Ethernet1/5
+  description duplicate_ip_not_connected
+  no switchport
+  ip address 10.200.0.1/32
+  no shutdown
 
 interface Ethernet1/6
 

--- a/network_importer/adapters/netbox_api/models.py
+++ b/network_importer/adapters/netbox_api/models.py
@@ -294,7 +294,7 @@ class NetboxIPAddress(IPAddress):
 
     remote_id: Optional[int]
 
-    def translate_attrs_for_netbox(self, attrs):
+    def translate_attrs_for_netbox(self, attrs=None):  # pylint: disable=unused-argument
         """Translate IP address attributes into NetBox format.
 
         Args:
@@ -305,17 +305,14 @@ class NetboxIPAddress(IPAddress):
         """
         nb_params = {"address": self.address}
 
-        if "interface_name" in attrs and "device_name" in attrs:
-
-            try:
-                interface = self.diffsync.get(
-                    self.diffsync.interface,
-                    identifier=dict(device_name=attrs["device_name"], name=attrs["interface_name"]),
-                )
-                nb_params["assigned_object_type"] = "dcim.interface"
-                nb_params["assigned_object_id"] = interface.remote_id
-            except ObjectNotFound:
-                pass
+        try:
+            interface = self.diffsync.get(
+                self.diffsync.interface, identifier=dict(device_name=self.device_name, name=self.interface_name),
+            )
+            nb_params["assigned_object_type"] = "dcim.interface"
+            nb_params["assigned_object_id"] = interface.remote_id
+        except ObjectNotFound:
+            pass
 
         return nb_params
 
@@ -401,26 +398,24 @@ class NetboxIPAddressPre29(NetboxIPAddress):
     The method to attach an ip address to an interface changed in 2.9, this class implement the old method
     """
 
-    def translate_attrs_for_netbox(self, attrs):
+    def translate_attrs_for_netbox(self, attrs=None):
         """Translate IP address attributes into NetBox 2.8 format.
 
         Args:
-            attrs (dict): Dictionnary of attributes of the object to translate
+            attrs (dict, Optional): Dictionnary of attributes of the object to translate
 
         Returns:
             dict: Netbox parameters
         """
         nb_params = {"address": self.address}
 
-        if "interface_name" in attrs and "device_name" in attrs:
-            try:
-                interface = self.diffsync.get(
-                    self.diffsync.interface,
-                    identifier=dict(device_name=attrs["device_name"], name=attrs["interface_name"]),
-                )
-                nb_params["interface"] = interface.remote_id
-            except ObjectNotFound:
-                pass
+        try:
+            interface = self.diffsync.get(
+                self.diffsync.interface, identifier=dict(device_name=self.device_name, name=self.interface_name),
+            )
+            nb_params["interface"] = interface.remote_id
+        except ObjectNotFound:
+            pass
 
         return nb_params
 

--- a/network_importer/models.py
+++ b/network_importer/models.py
@@ -104,12 +104,11 @@ class IPAddress(DiffSyncModel):
     """
 
     _modelname = "ip_address"
-    _identifiers = ("address",)
-    _attributes = ("device_name", "interface_name")
+    _identifiers = ("device_name", "interface_name", "address")
 
+    device_name: str
+    interface_name: str
     address: str
-    interface_name: Optional[str]
-    device_name: Optional[str]
 
 
 class Prefix(DiffSyncModel):

--- a/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress.py
@@ -23,13 +23,10 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 def test_translate_attrs_for_netbox_with_intf(netbox_api_base):
 
     ipaddr = NetboxIPAddress(
-        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/2", remote_id=30
+        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/1", remote_id=302
     )
     netbox_api_base.add(ipaddr)
-
-    params = ipaddr.translate_attrs_for_netbox(
-        attrs=dict(device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/1")
-    )
+    params = ipaddr.translate_attrs_for_netbox()
 
     assert "address" in params
     assert params["address"] == "10.10.10.1/24"
@@ -42,11 +39,10 @@ def test_translate_attrs_for_netbox_with_intf(netbox_api_base):
 def test_translate_attrs_for_netbox_wo_intf(netbox_api_base):
 
     ipaddr = NetboxIPAddress(
-        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/2", remote_id=30
+        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/2", remote_id=302
     )
     netbox_api_base.add(ipaddr)
-
-    params = ipaddr.translate_attrs_for_netbox(attrs={})
+    params = ipaddr.translate_attrs_for_netbox()
 
     assert "address" in params
     assert params["address"] == "10.10.10.1/24"
@@ -74,8 +70,8 @@ def test_create_ip_address_interface(requests_mock, netbox_api_base):
     requests_mock.post("http://mock/api/ipam/ip-addresses/", json=data, status_code=201)
     ip_address = NetboxIPAddress.create(
         diffsync=netbox_api_base,
-        ids=dict(address="10.63.0.2/31"),
-        attrs=dict(interface_name="TenGigabitEthernet1/0/1", device_name="HQ-CORE-SW02"),
+        ids=dict(address="10.63.0.2/31", interface_name="TenGigabitEthernet1/0/1", device_name="HQ-CORE-SW02"),
+        attrs=dict(),
     )
 
     assert isinstance(ip_address, NetboxIPAddress) is True
@@ -88,7 +84,11 @@ def test_create_ip_address_no_interface(requests_mock, netbox_api_base):
         data = yaml.safe_load(file)
 
     requests_mock.post("http://mock/api/ipam/ip-addresses/", json=data, status_code=201)
-    ip_address = NetboxIPAddress.create(diffsync=netbox_api_base, ids=dict(address="10.63.0.2/31"), attrs=dict())
+    ip_address = NetboxIPAddress.create(
+        diffsync=netbox_api_base,
+        ids=dict(address="10.63.0.2/31", interface_name="TenGigabitEthernet1/0/1", device_name="HQ-CORE-SW02"),
+        attrs=dict(),
+    )
 
     assert isinstance(ip_address, NetboxIPAddress) is True
     assert ip_address.remote_id == 15

--- a/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress_pre29.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress_pre29.py
@@ -23,13 +23,11 @@ ROOT = os.path.abspath(os.path.dirname(__file__))
 def test_translate_attrs_for_netbox_with_intf(netbox_api_base):
 
     ipaddr = NetboxIPAddressPre29(
-        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/2", remote_id=30
+        address="10.10.10.1/24", device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/1", remote_id=302
     )
     netbox_api_base.add(ipaddr)
 
-    params = ipaddr.translate_attrs_for_netbox(
-        attrs=dict(device_name="HQ-CORE-SW02", interface_name="TenGigabitEthernet1/0/1")
-    )
+    params = ipaddr.translate_attrs_for_netbox()
 
     assert "address" in params
     assert params["address"] == "10.10.10.1/24"
@@ -44,7 +42,7 @@ def test_translate_attrs_for_netbox_wo_intf(netbox_api_base):
     )
     netbox_api_base.add(ipaddr)
 
-    params = ipaddr.translate_attrs_for_netbox(attrs={})
+    params = ipaddr.translate_attrs_for_netbox()
 
     assert "address" in params
     assert params["address"] == "10.10.10.1/24"
@@ -58,9 +56,7 @@ def test_translate_attrs_for_netbox_wrong_dev(netbox_api_base):
     )
     netbox_api_base.add(ipaddr)
 
-    params = ipaddr.translate_attrs_for_netbox(
-        attrs=dict(device_name="HQ-CORE-SW99", interface_name="TenGigabitEthernet1/0/1")
-    )
+    params = ipaddr.translate_attrs_for_netbox()
 
     assert "address" in params
     assert params["address"] == "10.10.10.1/24"

--- a/tests/unit/adapters/network_importer/test_add_prefix_from_ip.py
+++ b/tests/unit/adapters/network_importer/test_add_prefix_from_ip.py
@@ -20,7 +20,9 @@ def test_add_prefix_from_ip_base(network_importer_base, site_sfo):
     adapter = network_importer_base
     adapter.add(site_sfo)
 
-    prefix = adapter.add_prefix_from_ip(ip_address=IPAddress(address="10.10.10.1/24"), site=site_sfo)
+    prefix = adapter.add_prefix_from_ip(
+        ip_address=IPAddress(address="10.10.10.1/24", device_name="device1", interface_name="Intf1"), site=site_sfo
+    )
 
     assert isinstance(prefix, Prefix)
     assert adapter.get(Prefix, identifier=prefix.get_unique_id())
@@ -31,7 +33,9 @@ def test_add_prefix_from_ip_mask_32(network_importer_base, site_sfo):
     adapter = network_importer_base
     adapter.add(site_sfo)
 
-    prefix = adapter.add_prefix_from_ip(ip_address=IPAddress(address="10.10.10.1/32"), site=site_sfo)
+    prefix = adapter.add_prefix_from_ip(
+        ip_address=IPAddress(address="10.10.10.1/32", device_name="device1", interface_name="Intf1"), site=site_sfo
+    )
 
     assert prefix is False
 
@@ -41,7 +45,9 @@ def test_add_prefix_from_ip_mask_31(network_importer_base, site_sfo):
     adapter = network_importer_base
     adapter.add(site_sfo)
 
-    prefix = adapter.add_prefix_from_ip(ip_address=IPAddress(address="10.10.10.1/31"), site=site_sfo)
+    prefix = adapter.add_prefix_from_ip(
+        ip_address=IPAddress(address="10.10.10.1/31", device_name="device1", interface_name="Intf1"), site=site_sfo
+    )
 
     assert isinstance(prefix, Prefix)
     assert adapter.get(Prefix, identifier=prefix.get_unique_id())


### PR DESCRIPTION
Fixes #158

This PR changes the IPAddress model to support duplicate ip addresses across the network.
`device_name` and `interface_name` are now mandatory for an IPAddress object.