### PR TITLE
Apply DiffSync Flags based on Tags

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -52,7 +52,19 @@ verify_ssl = true                                   # Alternative Env Variable :
 # Define a list of supported platform, 
 # if defined all devices without platform or with a different platforms will be removed from the inventory
 supported_platforms = [ "cisco_ios", "cisco_nxos" ]
+
+# Settings for applying diffsync flags to diffsync model objects, in order to alter 
+# the underlying sync behaviour. The model_flag is applied to any objects that have a 
+# tag assigned within model_flag_tags. Further details on model_flags can be found 
+# at: https://github.com/networktocode/diffsync/blob/269df51ce248beaef17d72374e96d19e6df95a13/diffsync/enum.py
+model_flag_tags = ["your_tag"]
+model_flag = 1 # flag enum int() representation
 ```
+
+
+    model_flag_tags: List[str] = list() # List of tags that defines what objects to assign the model_flag to.
+    model_flag: Optional[DiffSyncModelFlags]  # The model flag that will be applied to objects based on tag.
+
 
 ## Batfish Section
 

--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -66,7 +66,7 @@ class NetBoxAPIAdapter(BaseAdapter):
     @staticmethod
     def _is_tag_present(netbox_obj):
         """Find if tag is present for a given object."""
-        if isinstance(netbox_obj, dict) and netbox_obj.get("tags", None):  # pylint: disable=no-else-return
+        if isinstance(netbox_obj, dict) and not netbox_obj.get("tags", None):  # pylint: disable=no-else-return
             return False
         elif not isinstance(netbox_obj, dict):  # pylint: disable=no-else-return
             try:

--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -66,7 +66,6 @@ class NetBoxAPIAdapter(BaseAdapter):
     @staticmethod
     def _is_tag_present(netbox_obj):
         """Find if tag is present for a given object."""
-
         if isinstance(netbox_obj, dict) and netbox_obj.get("tags", None):  # pylint: disable=no-else-return
             return False
         elif not isinstance(netbox_obj, dict):  # pylint: disable=no-else-return
@@ -87,8 +86,7 @@ class NetBoxAPIAdapter(BaseAdapter):
 
     @staticmethod
     def apply_model_flag(diffsync_obj, netbox_obj):
-        """Helper function for DiffSync Flag assignment"""
-
+        """Helper function for DiffSync Flag assignment."""
         model_flag = config.SETTINGS.netbox.model_flag
 
         if model_flag and NetBoxAPIAdapter._is_tag_present(netbox_obj):

--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -70,7 +70,7 @@ class NetBoxAPIAdapter(BaseAdapter):
             return False
         elif not isinstance(netbox_obj, dict):  # pylint: disable=no-else-return
             try:
-                pass
+                netbox_obj["tags"]
             except AttributeError:
                 return False
         elif not netbox_obj["tags"]:

--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -443,7 +443,7 @@ class NetBoxAPIAdapter(BaseAdapter):
             return False
 
         intf = self.interface(name=intf_name, device_name=device_name, remote_id=intfs[0].id)
-        intf = self.apply_model_flag(intfs[0], intf)
+        intf = self.apply_model_flag(intf, intfs[0])
 
         if intfs[0].connected_endpoint_type:
             intf.connected_endpoint_type = intfs[0].connected_endpoint_type

--- a/network_importer/adapters/netbox_api/adapter.py
+++ b/network_importer/adapters/netbox_api/adapter.py
@@ -20,7 +20,6 @@ import pynetbox
 from packaging.version import Version, InvalidVersion
 
 from diffsync.exceptions import ObjectAlreadyExists, ObjectNotFound
-
 import network_importer.config as config  # pylint: disable=import-error
 from network_importer.adapters.base import BaseAdapter  # pylint: disable=import-error
 from network_importer.adapters.netbox_api.models import (  # pylint: disable=import-error
@@ -63,6 +62,41 @@ class NetBoxAPIAdapter(BaseAdapter):
     type = "Netbox"
 
     query_device_info_from_netbox = query_device_info_from_netbox
+
+    @staticmethod
+    def _is_tag_present(netbox_obj):
+        """Find if tag is present for a given object."""
+
+        if isinstance(netbox_obj, dict) and netbox_obj.get("tags", None):  # pylint: disable=no-else-return
+            return False
+        elif not isinstance(netbox_obj, dict):  # pylint: disable=no-else-return
+            try:
+                pass
+            except AttributeError:
+                return False
+        elif not netbox_obj["tags"]:
+            return False
+
+        for tag in config.SETTINGS.netbox.model_flag_tags:
+            if tag in netbox_obj["tags"]:
+                LOGGER.debug(
+                    "Tag (%s) found for object %s. Marked for diffsync flag assignment.", tag, netbox_obj,
+                )
+                return True
+        return False
+
+    @staticmethod
+    def apply_model_flag(diffsync_obj, netbox_obj):
+        """Helper function for DiffSync Flag assignment"""
+
+        model_flag = config.SETTINGS.netbox.model_flag
+
+        if model_flag and NetBoxAPIAdapter._is_tag_present(netbox_obj):
+            LOGGER.info(
+                "DiffSync model flag (%s) applied to object %s", model_flag, netbox_obj,
+            )
+            diffsync_obj.model_flags = model_flag
+        return diffsync_obj
 
     def _check_netbox_version(self):
         """Check the version of Netbox defined in the configuration and load the proper models as needed.
@@ -117,6 +151,7 @@ class NetBoxAPIAdapter(BaseAdapter):
             if nb_device["primary_ip"]:
                 device.primary_ip = nb_device["primary_ip"].get("address")
 
+            device = self.apply_model_flag(device, nb_device)
             self.add(device)
 
         # Load Prefix and Vlan per site
@@ -159,6 +194,7 @@ class NetBoxAPIAdapter(BaseAdapter):
         for nb_prefix in prefixes:
 
             prefix = self.prefix(prefix=nb_prefix.prefix, site_name=site.name, remote_id=nb_prefix.id,)
+            prefix = self.apply_model_flag(prefix, nb_prefix)
 
             if nb_prefix.vlan:
                 prefix.vlan = self.vlan.create_unique_id(vid=nb_prefix.vlan.vid, site_name=site.name)
@@ -409,6 +445,7 @@ class NetBoxAPIAdapter(BaseAdapter):
             return False
 
         intf = self.interface(name=intf_name, device_name=device_name, remote_id=intfs[0].id)
+        intf = self.apply_model_flag(intfs[0], intf)
 
         if intfs[0].connected_endpoint_type:
             intf.connected_endpoint_type = intfs[0].connected_endpoint_type

--- a/network_importer/adapters/netbox_api/models.py
+++ b/network_importer/adapters/netbox_api/models.py
@@ -330,6 +330,8 @@ class NetboxIPAddress(IPAddress):
         item = cls(
             address=obj.address, device_name=device_name, interface_name=obj.assigned_object.name, remote_id=obj.id
         )
+
+        item = diffsync.apply_model_flag(item, obj)
         return item
 
     @classmethod
@@ -431,6 +433,8 @@ class NetboxIPAddressPre29(NetboxIPAddress):
             NetboxIPAddress: DiffSync object
         """
         item = cls(address=obj.address, device_name=device_name, interface_name=obj.interface.name, remote_id=obj.id)
+        item = diffsync.apply_model_flag(item, obj)
+
         return item
 
 
@@ -589,6 +593,8 @@ class NetboxVlan(Vlan):
                 item.add_device(device_name)
                 device.device_tag_id = tag["id"]
 
+        item = diffsync.apply_model_flag(item, obj)
+
         return item
 
     @classmethod
@@ -708,6 +714,8 @@ class NetboxVlanPre29(NetboxVlan):
                     item.add_device(device)
                 except ObjectNotFound:
                     pass
+
+        item = diffsync.apply_model_flag(item, obj)
 
         return item
 

--- a/network_importer/config.py
+++ b/network_importer/config.py
@@ -22,6 +22,7 @@ from typing import List, Dict, Optional, Union
 import toml
 from pydantic import BaseSettings, ValidationError
 from typing_extensions import Literal
+from diffsync import DiffSyncModelFlags
 
 SETTINGS = None
 
@@ -63,6 +64,9 @@ class NetboxSettings(BaseSettings):
     address: str = "http://localhost"
     token: Optional[str]
     verify_ssl: bool = True
+
+    model_flag_tags: List[str] = list()  # List of tags that defines what objects to assign the model_flag to.
+    model_flag: Optional[DiffSyncModelFlags]  # The model flag that will be applied to objects based on tag.
 
     """Define a list of supported platform,
     if defined all devices without platform or with a different platforms will be removed from the inventory"""


### PR DESCRIPTION
This commit adds the ability to apply a diffsync flag to a model based on 1 or more Netbox tags.
This is in turn allows you to affect the sync behaviour of the objects based on the model flags described here:
https://github.com/networktocode/diffsync/blob/269df51ce248beaef17d72374e96d19e6df95a13/diffsync/enum.py#L21
