### PR TITLE
Add driver to inventory command

### DIFF
--- a/network_importer/cli.py
+++ b/network_importer/cli.py
@@ -187,6 +187,7 @@ def inventory(config_file, limit, debug, update_configs):
 
     table.add_column("Device", style="cyan", no_wrap=True)
     table.add_column("Platform", style="magenta")
+    table.add_column("Driver")
     table.add_column("Reachable")
     table.add_column("Reason")
 
@@ -198,7 +199,8 @@ def inventory(config_file, limit, debug, update_configs):
             is_reachable = "[red]False"
             reason = f"[red]{host.data['not_reachable_reason']}"
 
-        table.add_row(hostname, host.data["vendor"], is_reachable, reason)
+        driver = config.SETTINGS.drivers.mapping.get(host.platform, config.SETTINGS.drivers.mapping.get("default"))
+        table.add_row(hostname, host.platform, driver, is_reachable, reason)
 
     console = Console()
     console.print(table)


### PR DESCRIPTION
This PR updates the inventory command to properly show the platform of the device, instead of the manufacturer, and adds the name of the driver associated with each device

```
┏━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
┃ Device       ┃ Platform  ┃ Driver                                 ┃ Reachable ┃ Reason                           ┃
┡━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
│ hou-bb-01    │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-leaf-01  │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-leaf-02  │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-rtr-01   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-rtr-02   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-spine-01 │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ hou-spine-02 │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ nyc-bb-01    │ cisco_ios │ network_importer.drivers.cisco_default │ False     │ primary ip not defined in Netbox │
│ nyc-leaf-01  │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ nyc-rtr-01   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ nyc-rtr-02   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ nyc-spine-01 │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ nyc-spine-02 │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ sjc-bb-01    │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ sjc-leaf-01  │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ sjc-rtr-01   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
│ sjc-rtr-02   │           │ network_importer.drivers.default       │ False     │ primary ip not defined in Netbox │
└──────────────┴───────────┴────────────────────────────────────────┴───────────┴──────────────────────────────────┘
```