### PR TITLE
Refactor inventory to pass netmiko_extras and napalm_extras

### DIFF
--- a/network_importer/adapters/nautobot_api/settings.py
+++ b/network_importer/adapters/nautobot_api/settings.py
@@ -22,9 +22,6 @@ class InventorySettings(BaseSettings):
     use_primary_ip: Optional[bool] = True
     fqdn: Optional[str] = None
     filter: Optional[str] = None
-    global_delay_factor: Optional[int] = 5
-    banner_timeout: Optional[int] = 15
-    conn_timeout: Optional[int] = 5
 
     class Config:
         """Additional parameters to automatically map environment variable to some settings."""

--- a/network_importer/adapters/netbox_api/settings.py
+++ b/network_importer/adapters/netbox_api/settings.py
@@ -22,9 +22,6 @@ class InventorySettings(BaseSettings):
     use_primary_ip: Optional[bool] = True
     fqdn: Optional[str] = None
     filter: Optional[str] = ""
-    global_delay_factor: Optional[int] = 5
-    banner_timeout: Optional[int] = 15
-    conn_timeout: Optional[int] = 5
 
     class Config:
         """Additional parameters to automatically map environment variable to some settings."""

--- a/network_importer/config.py
+++ b/network_importer/config.py
@@ -64,9 +64,10 @@ class NetworkSettings(BaseSettings):
     login: Optional[str]
     password: Optional[str]
     enable: bool = True
-    global_delay_factor: int = 5
-    banner_timeout: int = 15
-    conn_timeout: int = 5
+
+    netmiko_extras: Optional[dict]
+    napalm_extras: Optional[dict]
+
     fqdns: List[str] = list()  # List of valid FQDN that can be found in the network
 
     class Config:

--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -75,6 +75,8 @@ class NetworkImporter:
                     "password": config.SETTINGS.network.password,
                     "enable": config.SETTINGS.network.enable,
                     "supported_platforms": config.SETTINGS.inventory.supported_platforms,
+                    "netmiko_extras": config.SETTINGS.network.netmiko_extras,
+                    "napalm_extras": config.SETTINGS.network.napalm_extras,
                     "limit": limit,
                     "settings": config.SETTINGS.inventory.settings,
                 },

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_device.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_device.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotDevice model."""
 import os
 import yaml
 

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_interface.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_interface.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotInterface model."""
 import os
 import pytest
 

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_ipaddress.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_ipaddress.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotIPAddress model."""
 import os
 import yaml
 import pynautobot

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_prefix.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_prefix.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotPrefix model."""
 import os
 import yaml
 

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_vlan.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_vlan.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotVlan model."""
 import os
 
 import pynautobot

--- a/tests/unit/adapters/nautobot_api/test_nautobot_inventory.py
+++ b/tests/unit/adapters/nautobot_api/test_nautobot_inventory.py
@@ -1,16 +1,4 @@
-"""
-(c) 2019 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NautobotAPI Inventory."""
 # pylint: disable=E1101
 
 from os import path

--- a/tests/unit/adapters/nautobot_api/test_nautobot_inventory.py
+++ b/tests/unit/adapters/nautobot_api/test_nautobot_inventory.py
@@ -37,14 +37,7 @@ def test_nautobot_inventory_all(requests_mock):
     data2 = yaml.safe_load(open(f"{HERE}/{FIXTURES}/platforms.json"))
     requests_mock.get("http://mock/api/dcim/platforms/", json=data2)
 
-    inv = NautobotAPIInventory(
-        settings=dict(address="http://mock", token="12349askdnfanasdf"),
-        username="mock",
-        password="mock",
-        enable="mock",
-        supported_platforms=["cisco_ios", "nxos", "ios"],
-        limit=None,
-    ).load()  # nosec
+    inv = NautobotAPIInventory(settings=dict(address="http://mock", token="12349askdnfanasdf"),).load()  # nosec
 
     assert len(inv.hosts.keys()) == 3
     assert "grb-rtr01" in inv.hosts.keys()
@@ -66,7 +59,6 @@ def test_nb_inventory_filtered(requests_mock):
         by pytest library, mocks requests get to external API so external API call is
         not needed for unit test.
     """
-
     # Load mock data fixtures
     data1 = yaml.safe_load(open(f"{HERE}/{FIXTURES}/filtered_devices.json"))
     requests_mock.get("http://mock/api/dcim/devices/?name=grb-rtr01&exclude=config_context", json=data1)
@@ -75,12 +67,7 @@ def test_nb_inventory_filtered(requests_mock):
     requests_mock.get("http://mock/api/dcim/platforms/", json=data2)
 
     inv_filtered = NautobotAPIInventory(
-        username="mock",
-        password="mock",
-        enable="mock",
-        supported_platforms=["cisco_ios", "nxos", "ios"],
-        limit="grb-rtr01",
-        settings=dict(address="http://mock", token="12349askdnfanasdf",),  # nosec
+        limit="grb-rtr01", settings=dict(address="http://mock", token="12349askdnfanasdf",),  # nosec
     ).load()  # nosec
 
     assert len(inv_filtered.hosts.keys()) == 1
@@ -97,7 +84,6 @@ def test_nb_inventory_exclude(requests_mock):
         by pytest library, mocks requests get to external API so external API call is
         not needed for unit test.
     """
-
     # Load mock data fixtures
     data1 = yaml.safe_load(open(f"{HERE}/{FIXTURES}/devices.json"))
     requests_mock.get("http://mock/api/dcim/devices/?exclude=platform", json=data1)
@@ -106,11 +92,6 @@ def test_nb_inventory_exclude(requests_mock):
     requests_mock.get("http://mock/api/dcim/platforms/", json=data2)
 
     inv = NautobotAPIInventory(
-        username="mock",
-        password="mock",
-        enable="mock",
-        supported_platforms=["cisco_ios", "nxos", "ios"],
-        limit=None,
         settings=dict(address="http://mock", token="12349askdnfanasdf", filter="exclude=platform",),  # nosec  # nosec
     ).load()  # nosec
 
@@ -126,7 +107,6 @@ def test_nb_inventory_virtual_chassis(requests_mock):
         by pytest library, mocks requests get to external API so external API call is
         not needed for unit test.
     """
-
     # Load mock data fixtures
     data1 = yaml.safe_load(open(f"{HERE}/{FIXTURES}/stack_devices.json"))
     requests_mock.get("http://mock/api/dcim/devices/", json=data1)
@@ -159,7 +139,6 @@ def test_nb_inventory_supported_platforms(requests_mock):
         by pytest library, mocks requests get to external API so external API call is
         not needed for unit test.
     """
-
     # Load mock data fixtures
     data1 = yaml.safe_load(open(f"{HERE}/{FIXTURES}/devices.json"))
     requests_mock.get("http://mock/api/dcim/devices/", json=data1)
@@ -168,11 +147,7 @@ def test_nb_inventory_supported_platforms(requests_mock):
     requests_mock.get("http://mock/api/dcim/platforms/", json=data2)
 
     inv = NautobotAPIInventory(
-        username="mock",
-        password="mock",
-        enable="mock",
-        limit=None,
-        supported_platforms=["ios", "nxos"],  # nosec
+        supported_platforms=["ios", "nxos"],
         settings=dict(address="http://mock", token="12349askdnfanasdf")  # nosec  # nosec
         # nosec
     ).load()  # nosec

--- a/tests/unit/adapters/netbox_api/models/test_netbox_device.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_device.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxDevice model."""
 import os
 import yaml
 

--- a/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxInterface model."""
 import os
 import pytest
 

--- a/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxIPAddress model."""
 import os
 import yaml
 import pynetbox

--- a/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress_pre29.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_ipaddress_pre29.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxIPAddressPre29 model."""
 import os
 import yaml
 import pynetbox

--- a/tests/unit/adapters/netbox_api/models/test_netbox_prefix.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_prefix.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxPrefix model."""
 import os
 import yaml
 

--- a/tests/unit/adapters/netbox_api/models/test_netbox_vlan.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_vlan.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxVlan model."""
 import os
 import yaml
 import pytest

--- a/tests/unit/adapters/netbox_api/models/test_netbox_vlan_pre29.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_vlan_pre29.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxVlanPre29 model."""
 import os
 import yaml
 import pytest

--- a/tests/unit/adapters/netbox_api/test_netbox_inventory.py
+++ b/tests/unit/adapters/netbox_api/test_netbox_inventory.py
@@ -1,16 +1,4 @@
-"""
-(c) 2019 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""test for NetboxAPI Inventory."""
 # pylint: disable=E1101
 
 from os import path


### PR DESCRIPTION
This PR refactors the inventory to generate the global group within the base inventory instead of having to redefine it for each  implementation. 
In the process, I removed some opinionated settings for Netmiko from the network configurations and I added 2 additional sections in the `[network]` section of the configuration to allow for more customizations : `netmiko_extras` and `napalm_extras` 

