### PR TITLE
Add support for backend to define inventory and sot adapter at once

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,3 +149,4 @@ dmypy.json
 .pyre/
 
 *.env
+.vscode

--- a/examples/multi_site_02/network_importer.toml
+++ b/examples/multi_site_02/network_importer.toml
@@ -6,7 +6,9 @@ import_prefixes = true
 import_cabling = "config"
 import_vlans = "config"
 
-nbr_workers = 1
+nbr_workers = 5
+
+backend = "netbox"
 
 [inventory.settings]
 filter="region=ni_multi_site_02"

--- a/examples/spine_leaf_01/network_importer.toml
+++ b/examples/spine_leaf_01/network_importer.toml
@@ -6,6 +6,8 @@ import_prefixes = true
 import_cabling = "config"
 import_vlans = "config"
 
+backend = "netbox"
+
 [inventory.settings]
 filter = "site=ni_spine_leaf_01"
 

--- a/network_importer/cli.py
+++ b/network_importer/cli.py
@@ -46,7 +46,7 @@ def main():
 
 def init(config_file):
     """Init Network-Importer."""
-    config.load(config_file_name=config_file)
+    config.load_and_exit(config_file_name=config_file)
     perf.init()
 
     # ------------------------------------------------------------

--- a/network_importer/config.py
+++ b/network_importer/config.py
@@ -113,8 +113,8 @@ class MainSettings(BaseSettings):
     you must leave backend empty and define inventory.inventory_class and adapters.sot_class manually."""
 
     # NOT SUPPORTED CURRENTLY
-    # generate_hostvars: bool = False
-    # hostvars_directory: str = "host_vars"
+    generate_hostvars: bool = False
+    hostvars_directory: str = "host_vars"
 
 
 class AdaptersSettings(BaseSettings):

--- a/network_importer/config.py
+++ b/network_importer/config.py
@@ -1,17 +1,4 @@
-"""Settings definition for the network importer.
-
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Settings definition for the network importer."""
 # pylint: disable=invalid-name,redefined-outer-name
 
 import os
@@ -23,6 +10,7 @@ import toml
 from pydantic import BaseSettings, ValidationError
 from typing_extensions import Literal
 
+from network_importer.exceptions import ConfigLoadFatalError
 
 SETTINGS = None
 
@@ -33,6 +21,17 @@ DEFAULT_DRIVERS_MAPPING = {
     "cisco_xr": "network_importer.drivers.cisco_default",
     "juniper_junos": "network_importer.drivers.juniper_junos",
     "arista_eos": "network_importer.drivers.arista_eos",
+}
+
+DEFAULT_BACKENDS = {
+    "netbox": {
+        "inventory": "NetBoxAPIInventory",
+        "adapter": "network_importer.adapters.netbox_api.adapter.NetBoxAPIAdapter",
+    },
+    "nautobot": {
+        "inventory": "NautobotAPIInventory",
+        "adapter": "network_importer.adapters.nautobot_api.adapter.NautobotAPIAdapter",
+    },
 }
 
 # pylint: disable=global-statement
@@ -109,9 +108,13 @@ class MainSettings(BaseSettings):
 
     configs_directory: str = "configs"
 
+    backend: Optional[Literal["nautobot", "netbox"]]
+    """Only Netbox and Nautobot backend are included by default, if you want to use another backend
+    you must leave backend empty and define inventory.inventory_class and adapters.sot_class manually."""
+
     # NOT SUPPORTED CURRENTLY
-    generate_hostvars: bool = False
-    hostvars_directory: str = "host_vars"
+    # generate_hostvars: bool = False
+    # hostvars_directory: str = "host_vars"
 
 
 class AdaptersSettings(BaseSettings):
@@ -120,7 +123,7 @@ class AdaptersSettings(BaseSettings):
     network_class: str = "network_importer.adapters.network_importer.adapter.NetworkImporterAdapter"
     network_settings: Optional[dict]
 
-    sot_class: str = "network_importer.adapters.netbox_api.adapter.NetBoxAPIAdapter"
+    sot_class: Optional[str]
     sot_settings: Optional[dict]
 
 
@@ -137,7 +140,7 @@ class InventorySettings(BaseSettings):
     if the use_primary_ip flag is disabled, the inventory will try to use the hostname to the device
     """
 
-    inventory_class: str = "NetBoxAPIInventory"
+    inventory_class: Optional[str]
     settings: Optional[dict]
 
     supported_platforms: List[str] = list()
@@ -159,33 +162,83 @@ class Settings(BaseSettings):
     inventory: InventorySettings = InventorySettings()
 
 
-def load(config_file_name="network_importer.toml", config_data=None):
-    """Load a configuration file in pyproject.toml format that contains the settings.
+def _configure_backend(settings: Settings):
+    """Configure the inventory and the SOT adapter for a given backend.
 
-    The settings for this app are expected to be in [tool.json_schema_testing] in TOML
-    if nothing is found in the config file or if the config file do not exist, the default values will be used.
+    The inventory and/or the adapter will be updated if:
+      - a backend provided is valid
+      - no value has been defined already
 
     Args:
-        config_file_name (str, optional): Name of the configuration file to load. Defaults to "pyproject.toml".
+        settings (Settings)
+
+    Returns:
+        Settings
+    """
+    if not settings.main.backend and (not settings.inventory.inventory_class or not settings.adapters.sot_class):
+        raise ConfigLoadFatalError(
+            "You must define a valid backend or assign inventory.inventory_class and adapters.sot_class manually."
+        )
+
+    if not settings.main.backend:
+        return settings
+
+    supported_backends = DEFAULT_BACKENDS.keys()
+    if settings.main.backend not in supported_backends:
+        raise ConfigLoadFatalError(f"backend value one of : {', '.join(supported_backends)}")
+
+    if not settings.inventory.inventory_class:
+        settings.inventory.inventory_class = DEFAULT_BACKENDS[settings.main.backend]["inventory"]
+
+    if not settings.adapters.sot_class:
+        settings.adapters.sot_class = DEFAULT_BACKENDS[settings.main.backend]["adapter"]
+
+    return settings
+
+
+def load(config_file_name="network_importer.toml", config_data=None):
+    """Load configuration.
+
+    Configuration is loaded from a file in network_importer.toml format that contains the settings,
+    or from a dictionary of those settings passed in as "config_data"
+
+    Args:
+        config_file_name (str, optional): Name of the configuration file to load. Defaults to "network_importer.toml".
         config_data (dict, optional): dict to load as the config file instead of reading the file. Defaults to None.
     """
     global SETTINGS
 
     if config_data:
-        SETTINGS = Settings(**config_data)
+        SETTINGS = _configure_backend(Settings(**config_data))
         return
 
     if os.path.exists(config_file_name):
         config_string = Path(config_file_name).read_text()
         config_tmp = toml.loads(config_string)
-
-        try:
-            SETTINGS = Settings(**config_tmp)
-            return
-        except ValidationError as e:
-            print(f"Configuration not valid, found {len(e.errors())} error(s)")
-            for error in e.errors():
-                print(f"  {'/'.join(error['loc'])} | {error['msg']} ({error['type']})")
-            sys.exit(1)
+        SETTINGS = _configure_backend(Settings(**config_tmp))
+        return
 
     SETTINGS = Settings()
+
+
+def load_and_exit(config_file_name="network_importer.toml", config_data=None):
+    """Calls load, but wraps it in a try except block.
+
+    This is done to handle a ValidationError which is raised when settings are specified but invalid.
+    In such cases, a message is printed to the screen indicating the settings which don't pass validation.
+
+    Args:
+        config_file_name (str, optional): [description]. Defaults to "network_importer.toml".
+        config_data (dict, optional): [description]. Defaults to None.
+    """
+    try:
+        load(config_file_name=config_file_name, config_data=config_data)
+    except ValidationError as err:
+        print(f"Configuration not valid, found {len(err.errors())} error(s)")
+        for error in err.errors():
+            print(f"  {'/'.join(error['loc'])} | {error['msg']} ({error['type']})")
+        sys.exit(1)
+    except ConfigLoadFatalError as err:
+        print("Configuration not valid")
+        print(f"  {err}")
+        sys.exit(1)

--- a/network_importer/exceptions.py
+++ b/network_importer/exceptions.py
@@ -1,18 +1,9 @@
-"""Custom Exceptions for the NetworkImporterAdapter.
-
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Custom Exceptions for the NetworkImporterAdapter."""
 
 
 class AdapterLoadFatalError(Exception):
+    """Network Importer Exception."""
+
+
+class ConfigLoadFatalError(Exception):
     """Network Importer Exception."""

--- a/network_importer/main.py
+++ b/network_importer/main.py
@@ -1,22 +1,11 @@
-"""main class for the network importer.
-
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""main class for the network importer."""
 import logging
 import os
 import sys
 import warnings
 import importlib
+
+from pydantic import ValidationError
 
 import network_importer.config as config
 from network_importer.exceptions import AdapterLoadFatalError
@@ -119,6 +108,11 @@ class NetworkImporter:
         try:
             self.sot = sot_adapter(nornir=self.nornir, settings=sot_settings)
             self.sot.load()
+        except ValidationError as exc:
+            print(f"Configuration not valid, found {len(exc.errors())} error(s)")
+            for error in exc.errors():
+                print(f"  {'/'.join(error['loc'])} | {error['msg']} ({error['type']})")
+            sys.exit(1)
         except AdapterLoadFatalError as exc:
             LOGGER.error("Unable to load the SOT Adapter : %s", exc)
             sys.exit(1)
@@ -132,6 +126,11 @@ class NetworkImporter:
         try:
             self.network = network_adapter(nornir=self.nornir, settings=network_adapter_settings)
             self.network.load()
+        except ValidationError as exc:
+            print(f"Configuration not valid, found {len(exc.errors())} error(s)")
+            for error in exc.errors():
+                print(f"  {'/'.join(error['loc'])} | {error['msg']} ({error['type']})")
+            sys.exit(1)
         except AdapterLoadFatalError as exc:
             LOGGER.error("Unable to load the SOT Adapter : %s", exc)
             sys.exit(1)

--- a/tests/unit/adapters/nautobot_api/models/test_nautobot_interface.py
+++ b/tests/unit/adapters/nautobot_api/models/test_nautobot_interface.py
@@ -42,7 +42,7 @@ def test_translate_attrs_for_nautobot_device_no_remote_id(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_no_attrs(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -58,7 +58,7 @@ def test_translate_attrs_for_nautobot_no_attrs(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_type(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -77,7 +77,7 @@ def test_translate_attrs_for_nautobot_type(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_description(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -98,7 +98,7 @@ def test_translate_attrs_for_nautobot_description(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_mode(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -124,7 +124,7 @@ def test_translate_attrs_for_nautobot_vlan(nautobot_api_base):
     vlan = NautobotVlan(vid=100, site_name="HQ", remote_id="601077ce-ac88-4b36-bbc7-23d655dc3958")
     nautobot_api_base.add(vlan)
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -169,7 +169,7 @@ def test_translate_attrs_for_nautobot_vlan(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_vlan_false(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -190,7 +190,7 @@ def test_translate_attrs_for_nautobot_vlan_false(nautobot_api_base):
 
 def test_translate_attrs_for_nautobot_vlan_no(nautobot_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans="no")))
+    config.load(config_data=dict(main=dict(import_vlans="no", backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 
@@ -216,7 +216,7 @@ def test_translate_attrs_for_nautobot_lag_member(nautobot_api_base):
     )
     nautobot_api_base.add(parent)
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="nautobot")))
     intf = NautobotInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     nautobot_api_base.add(intf)
 

--- a/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
+++ b/tests/unit/adapters/netbox_api/models/test_netbox_interface.py
@@ -44,7 +44,7 @@ def test_translate_attrs_for_netbox_device_no_remote_id(netbox_api_base):
 
 def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -60,7 +60,7 @@ def test_translate_attrs_for_netbox_no_attrs(netbox_api_base):
 
 def test_translate_attrs_for_netbox_type(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -79,7 +79,7 @@ def test_translate_attrs_for_netbox_type(netbox_api_base):
 
 def test_translate_attrs_for_netbox_description(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -100,7 +100,7 @@ def test_translate_attrs_for_netbox_description(netbox_api_base):
 
 def test_translate_attrs_for_netbox_mode(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -126,7 +126,7 @@ def test_translate_attrs_for_netbox_vlan(netbox_api_base):
     vlan = NetboxVlan(vid=100, site_name="HQ", remote_id=30)
     netbox_api_base.add(vlan)
 
-    config.load(config_data=dict(main=dict(import_vlans=True)))
+    config.load(config_data=dict(main=dict(import_vlans=True, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -169,7 +169,7 @@ def test_translate_attrs_for_netbox_vlan(netbox_api_base):
 
 def test_translate_attrs_for_netbox_vlan_false(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -188,7 +188,7 @@ def test_translate_attrs_for_netbox_vlan_false(netbox_api_base):
 
 def test_translate_attrs_for_netbox_vlan_no(netbox_api_base):
 
-    config.load(config_data=dict(main=dict(import_vlans="no")))
+    config.load(config_data=dict(main=dict(import_vlans="no", backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 
@@ -210,7 +210,7 @@ def test_translate_attrs_for_netbox_lag_member(netbox_api_base):
     parent = NetboxInterface(device_name="HQ-CORE-SW01", name="ge-0/0/4", remote_id=50)
     netbox_api_base.add(parent)
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="netbox")))
     intf = NetboxInterface(device_name="HQ-CORE-SW02", name="ge-0/0/0")
     netbox_api_base.add(intf)
 

--- a/tests/unit/adapters/network_importer/test_load_batfish_interface.py
+++ b/tests/unit/adapters/network_importer/test_load_batfish_interface.py
@@ -112,7 +112,7 @@ def test_load_batfish_interface_loopback(network_importer_base, site_sfo, dev_sp
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=LOOPBACK_1)
 
@@ -128,7 +128,7 @@ def test_load_batfish_interface_phy_intf_ether_std(network_importer_base, site_s
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=ETHERNET_1)
 
@@ -144,7 +144,7 @@ def test_load_batfish_interface_intf_ether_sub(network_importer_base, site_sfo, 
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=L3_SUB_INTF_1)
 
@@ -163,7 +163,7 @@ def test_load_batfish_interface_intf_lag_member(network_importer_base, site_sfo,
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=LAG_MEMBER_1)
 
@@ -180,7 +180,7 @@ def test_load_batfish_interface_intf_lag(network_importer_base, site_sfo, dev_sp
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=LAG_1)
 
@@ -197,7 +197,7 @@ def test_add_batfish_interface_intf_serial(network_importer_base, site_sfo, dev_
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=SERIAL_1)
 
@@ -216,7 +216,7 @@ def test_load_batfish_interface_description(network_importer_base, site_sfo, dev
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     data = LOOPBACK_1
     data["description"] = "  intf1 description  "
@@ -234,7 +234,7 @@ def test_load_batfish_intf_no_import_vlans_sub_intf(network_importer_base, site_
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="nautobot")))
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=L3_SUB_INTF_1)
 
     assert isinstance(intf, Interface)
@@ -248,7 +248,7 @@ def test_load_batfish_intf_no_import_vlans_lag(network_importer_base, site_sfo, 
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="nautobot")))
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=LAG_1)
 
     assert isinstance(intf, Interface)
@@ -262,7 +262,7 @@ def test_load_batfish_intf_no_import_vlans_lag_members(network_importer_base, si
     adapter.add(site_sfo)
     adapter.add(dev_spine1)
 
-    config.load(config_data=dict(main=dict(import_vlans=False)))
+    config.load(config_data=dict(main=dict(import_vlans=False, backend="nautobot")))
     intf = adapter.load_batfish_interface(site=site_sfo, device=dev_spine1, intf=LAG_MEMBER_1)
 
     assert isinstance(intf, Interface)

--- a/tests/unit/adapters/network_importer/test_load_batfish_ipaddress.py
+++ b/tests/unit/adapters/network_importer/test_load_batfish_ipaddress.py
@@ -25,7 +25,7 @@ def test_load_batfish_ipaddress_w_ip_w_prefix_no_vlan(network_importer_base, sit
     adapter.add(dev_spine1)
     intf1 = Interface(name="et-0/0/0", device_name=dev_spine1.name)
 
-    config.load(config_data=dict(main=dict(import_ips=True, import_prefixes=True)))
+    config.load(config_data=dict(main=dict(backend="nautobot", import_ips=True, import_prefixes=True)))
 
     ipaddr = adapter.load_batfish_ip_address(site=site_sfo, device=dev_spine1, interface=intf1, address="10.10.10.1/24")
     prefix = Prefix(prefix="10.10.10.0/24", site_name="sfo")
@@ -42,7 +42,7 @@ def test_load_batfish_ipaddress_wo_ip_wo_prefix(network_importer_base, site_sfo,
     adapter.add(dev_spine1)
     intf1 = Interface(name="et-0/0/0", device_name=dev_spine1.name)
 
-    config.load(config_data=dict(main=dict(import_ips=False, import_prefixes=False)))
+    config.load(config_data=dict(main=dict(backend="nautobot", import_ips=False, import_prefixes=False)))
 
     ipaddr = adapter.load_batfish_ip_address(site=site_sfo, device=dev_spine1, interface=intf1, address="10.10.10.1/24")
     prefix = Prefix(prefix="10.10.10.0/24", site_name="sfo")
@@ -61,7 +61,7 @@ def test_load_batfish_ipaddress_w_ip_wo_prefix(network_importer_base, site_sfo, 
     adapter.add(dev_spine1)
     intf1 = Interface(name="et-0/0/0", device_name=dev_spine1.name)
 
-    config.load(config_data=dict(main=dict(import_ips=True, import_prefixes=False)))
+    config.load(config_data=dict(main=dict(backend="nautobot", import_ips=True, import_prefixes=False)))
 
     ipaddr = adapter.load_batfish_ip_address(site=site_sfo, device=dev_spine1, interface=intf1, address="10.10.10.1/24")
     prefix = Prefix(prefix="10.10.10.0/24", site_name="sfo")
@@ -79,7 +79,7 @@ def test_load_batfish_ipaddress_wo_ip_w_prefix(network_importer_base, site_sfo, 
     adapter.add(dev_spine1)
     intf1 = Interface(name="et-0/0/0", device_name=dev_spine1.name)
 
-    config.load(config_data=dict(main=dict(import_ips=False, import_prefixes=True)))
+    config.load(config_data=dict(main=dict(backend="nautobot", import_ips=False, import_prefixes=True)))
 
     ipaddr = adapter.load_batfish_ip_address(site=site_sfo, device=dev_spine1, interface=intf1, address="10.10.10.1/24")
     prefix = Prefix(prefix="10.10.10.0/24", site_name="sfo")

--- a/tests/unit/processors/test_get_neighbors.py
+++ b/tests/unit/processors/test_get_neighbors.py
@@ -65,7 +65,7 @@ def dispatch_get_neighbors(task, **kwargs):
 
 def test_base(nornir):
     """Validate that the processor is working as expected with standard inputs."""
-    config.load()
+    config.load(config_data=dict(main=dict(backend="nautobot")))
 
     neighbors = Neighbors()
     neighbors.neighbors["intfa"].append(Neighbor(hostname="devicea", port="intfa"))
@@ -84,7 +84,7 @@ def test_base(nornir):
 
 def test_cleanup_fqdn(nornir):
     """Validate that we are cleaning up the FQDN from device name."""
-    config.load(config_data={"network": {"fqdns": ["test.com"]}})
+    config.load(config_data=dict(main=dict(backend="nautobot"), network=dict(fqdns=["test.com"])))
 
     neighbors = Neighbors()
     neighbors.neighbors["intfa"].append(Neighbor(hostname="devicea.test.com", port="intfa"))
@@ -103,7 +103,7 @@ def test_cleanup_fqdn(nornir):
 
 def test_cleanup_mac_address(nornir):
     """Validate that we are removing neighbor with a mac address name."""
-    config.load(config_data={"network": {"fqdns": ["test.com"]}})
+    config.load(config_data=dict(main=dict(backend="nautobot"), network=dict(fqdns=["test.com"])))
 
     neighbors = Neighbors()
     neighbors.neighbors["intfa"].append(Neighbor(hostname="devicea.test.com", port="intfa"))
@@ -122,7 +122,7 @@ def test_cleanup_mac_address(nornir):
 
 def test_cleanup_port(nornir):
     """Validate that we are cleaning up the port from port name."""
-    config.load(config_data={"network": {"fqdns": ["test.com"]}})
+    config.load(config_data=dict(main=dict(backend="nautobot"), network=dict(fqdns=["test.com"])))
 
     neighbors = Neighbors()
     neighbors.neighbors["intfa"].append(Neighbor(hostname="devicea", port="HundredGigE0/0/0/0"))

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -1,0 +1,39 @@
+"""unit test for config related functions."""
+import pytest
+
+from network_importer.exceptions import ConfigLoadFatalError
+from network_importer.config import _configure_backend, Settings, DEFAULT_BACKENDS
+
+TEST_BACKEND = list(DEFAULT_BACKENDS.keys())[0]
+
+
+def test_configure_backend_w_backend():
+
+    result = _configure_backend(Settings(main=dict(backend=TEST_BACKEND)))
+    assert result.inventory.inventory_class is not None
+    assert result.adapters.sot_class is not None
+
+    result = _configure_backend(
+        Settings(main=dict(backend=TEST_BACKEND), inventory=dict(inventory_class="myinventoryclass"))
+    )
+    assert result.inventory.inventory_class == "myinventoryclass"
+    assert result.adapters.sot_class is not None
+
+    result = _configure_backend(Settings(main=dict(backend=TEST_BACKEND), adapters=dict(sot_class="mysotclass")))
+    assert result.inventory.inventory_class is not None
+    assert result.adapters.sot_class == "mysotclass"
+
+
+def test_configure_backend_wo_backend():
+
+    with pytest.raises(ConfigLoadFatalError):
+        _configure_backend(Settings())
+
+    with pytest.raises(ConfigLoadFatalError):
+        _configure_backend(Settings(inventory=dict(inventory_class="myinventoryclass")))
+
+    result = _configure_backend(
+        Settings(adapters=dict(sot_class="mysotclass"), inventory=dict(inventory_class="myinventoryclass"))
+    )
+    assert result.adapters.sot_class == "mysotclass"
+    assert result.inventory.inventory_class == "myinventoryclass"

--- a/tests/unit/test_diff.py
+++ b/tests/unit/test_diff.py
@@ -1,16 +1,4 @@
-"""
-(c) 2020 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""Unit tests for NetworkImporterDiff."""
 from collections.abc import Iterable
 
 from network_importer.diff import NetworkImporterDiff

--- a/tests/unit/test_performance.py
+++ b/tests/unit/test_performance.py
@@ -1,16 +1,4 @@
-"""
-(c) 2019 Network To Code
-
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
-  http://www.apache.org/licenses/LICENSE-2.0
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
-"""
+"""unit tests for network_importer.performance."""
 
 from network_importer.performance import print_from_ms
 


### PR DESCRIPTION
This PR introduces a new concept of `Backend` to simplify how we can support multiple SOT (Netbox/ Nautobot) without making the configuration file too complex.

Currently, to switch from Netbox to Nautobot or vis versa, it's required to change 2 settings in the configuration : the sot_class and the inventory_class, and the format for both is not easy to understand for a novice user.
A backend is a combination of a SOT Adapter and an inventory which allow a user to only define one settings that will automatically change both the inventory and the Sot adapter.

To avoid any ambiguity, it's mandatory to define a `backend` in the configuration. 
As of now, only 2 backends are supported by default : `nautobot` and `netbox`. It's possible to support other backend by manually configuring both the sot_class and the inventory_class.

```
[main]
backend = "nautobot"
```

I'll add the documentation for this and the other changes introduced in my previous PR in a separate PR

