### PR TITLE
Add check-connectivity option in inventory and pull configs before printing status

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -33,22 +33,22 @@ You can validate the status of your inventory with the command `network-importer
 ```
 # network-importer inventory
                                            Device Inventory (all)
-┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━┓
-┃ Device                     ┃ Platform      ┃ Driver                                 ┃ Reachable ┃ Reason ┃
-┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━┩
-│ jcy-bb-01.infra.ntc.com    │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │        │
-│ jcy-rtr-01.infra.ntc.com   │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │        │
-│ jcy-rtr-02.infra.ntc.com   │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │        │
-│ jcy-spine-01.infra.ntc.com │ cisco_nxos    │ network_importer.drivers.cisco_default │ True      │        │
-│ jcy-spine-02.infra.ntc.com │ cisco_nxos    │ network_importer.drivers.cisco_default │ True      │        │
-│ nyc-bb-01.infra.ntc.com    │ juniper_junos │ network_importer.drivers.juniper_junos │ True      │        │
-│ nyc-leaf-01.infra.ntc.com  │ arista_eos    │ network_importer.drivers.arista_eos    │ True      │        │
-│ nyc-leaf-02.infra.ntc.com  │ arista_eos    │ network_importer.drivers.arista_eos    │ True      │        │
-│ nyc-rtr-01.infra.ntc.com   │ juniper_junos │ network_importer.drivers.juniper_junos │ True      │        │
-│ nyc-rtr-02.infra.ntc.com   │ juniper_junos │ network_importer.drivers.juniper_junos │ True      │        │
-│ nyc-spine-01.infra.ntc.com │ arista_eos    │ network_importer.drivers.arista_eos    │ True      │        │
-│ nyc-spine-02.infra.ntc.com │ arista_eos    │ network_importer.drivers.arista_eos    │ True      │        │
-└────────────────────────────┴───────────────┴────────────────────────────────────────┴───────────┴────────┘
+┏━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┳━━━━━━━━━━━┳━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┓
+┃ Device                     ┃ Platform      ┃ Driver                                 ┃ Reachable ┃ Reason                          ┃
+┡━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━╇━━━━━━━━━━━╇━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┩
+│ jcy-bb-01.infra.ntc.com    │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │                                 │
+│ jcy-rtr-01.infra.ntc.com   │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │                                 │
+│ jcy-rtr-02.infra.ntc.com   │ cisco_ios     │ network_importer.drivers.cisco_default │ True      │                                 │
+│ jcy-spine-01.infra.ntc.com │ cisco_nxos    │ network_importer.drivers.cisco_default │ True      │                                 │
+│ jcy-spine-02.infra.ntc.com │ cisco_nxos    │ network_importer.drivers.cisco_default │ True      │                                 │
+│ nyc-bb-01.infra.ntc.com    │ juniper_junos │ network_importer.drivers.juniper_junos │ True      │                                 │
+│ nyc-leaf-01.infra.ntc.com  │ arista_eos    │ network_importer.drivers.arista_eos    │ False     │ device not reachable on port 22 │
+│ nyc-leaf-02.infra.ntc.com  │ arista_eos    │ network_importer.drivers.arista_eos    │ False     │ device not reachable on port 22 │
+│ nyc-rtr-01.infra.ntc.com   │ juniper_junos │ network_importer.drivers.juniper_junos │ False     │ device not reachable on port 22 │
+│ nyc-rtr-02.infra.ntc.com   │ juniper_junos │ network_importer.drivers.juniper_junos │ False     │ device not reachable on port 22 │
+│ nyc-spine-01.infra.ntc.com │ arista_eos    │ network_importer.drivers.arista_eos    │ False     │ device not reachable on port 22 │
+│ nyc-spine-02.infra.ntc.com │ arista_eos    │ network_importer.drivers.arista_eos    │ False     │ device not reachable on port 22 │
+└────────────────────────────┴───────────────┴────────────────────────────────────────┴───────────┴─────────────────────────────────┘
 ```
 
 > the option `--check-connectivity` will try to connect to all devices on port 22 (tcp_ping)

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -28,7 +28,7 @@ To be able to connect to the device the following information needs to be define
 
 ##### Validate your inventory
 
-You can validate the status of your inventory with the command `network-importer inventory`
+You can validate the status of your inventory with the command `network-importer inventory --check-connectivity`
 
 ```
 # network-importer inventory
@@ -50,6 +50,8 @@ You can validate the status of your inventory with the command `network-importer
 │ nyc-spine-02.infra.ntc.com │ arista_eos    │ network_importer.drivers.arista_eos    │ True      │        │
 └────────────────────────────┴───────────────┴────────────────────────────────────────┴───────────┴────────┘
 ```
+
+> the option `--check-connectivity` will try to connect to all devices on port 22 (tcp_ping)
 
 #### Batfish
 


### PR DESCRIPTION
Currently the inventory command is showing a partial reachability status because it's not trying to connect to the device before printing the inventory. 

This PR adds a new option `--check-connectivity` to `network-importer inventory` to gather more information about the device before printing the inventory.

Also when `--update-configs` is provided, previously the configuration where pulled after printing the inventory, now the configuration will be retrieved before this way the inventory table will represent the accurate status and level of reachability of the devices in the inventory.