### PR TITLE
Use diffsync store methods

### DIFF
--- a/network_importer/adapters/base.py
+++ b/network_importer/adapters/base.py
@@ -50,8 +50,9 @@ class BaseAdapter(DiffSync):
         modelname = vlan.get_type()
         uid = vlan.get_unique_id()
 
-        if uid in self._data[modelname]:
-            return self._data[modelname][uid], False
+        existing_obj = self.get(modelname, uid)
+        if existing_obj:
+            return existing_obj, False
 
         self.add(vlan)
         if site:
@@ -72,8 +73,9 @@ class BaseAdapter(DiffSync):
         modelname = obj.get_type()
         uid = obj.get_unique_id()
 
-        if uid in self._data[modelname]:
-            return self._data[modelname][uid], False
+        existing_obj = self.get(modelname, uid)
+        if existing_obj:
+            return existing_obj, False
 
         self.add(obj)
 

--- a/tests/unit/adapters/network_importer/test_load_batfish_interface.py
+++ b/tests/unit/adapters/network_importer/test_load_batfish_interface.py
@@ -154,7 +154,7 @@ def test_load_batfish_interface_intf_ether_sub(network_importer_base, site_sfo, 
     assert not intf.is_lag_member
     assert intf.allowed_vlans == ["sfo__201"]
 
-    assert "sfo__201" in adapter._data["vlan"]  # pylint: disable=W0212
+    assert "sfo__201" in adapter.get_all("vlan")  # pylint: disable=W0212
 
 
 def test_load_batfish_interface_intf_lag_member(network_importer_base, site_sfo, dev_spine1):


### PR DESCRIPTION
Addresses #266 

Simply replaces the access to internal arguments of `diffsync` adapter by its public methods