### PR TITLE
Add extra error handling for creating vlans

### DIFF
--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -525,7 +525,7 @@ class NautobotVlan(Vlan):
                         nb_params["tags"].append(tag_id)
                 except pynautobot.core.query.RequestError:
                     # If there is an error with tag retrieval, ignore tags
-                    pass
+                    LOGGER.warning("Error with tag retrieval for device %s. Ignoring.", device_name)
 
         return nb_params
 

--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -519,8 +519,13 @@ class NautobotVlan(Vlan):
                     )
                     continue
 
-                tag_id = device.get_device_tag_id()
-                nb_params["tags"].append(tag_id)
+                try:
+                    tag_id = device.get_device_tag_id()
+                    if tag_id:
+                        nb_params["tags"].append(tag_id)
+                except pynautobot.core.query.RequestError:
+                    # If there is an error with tag retrieval, ignore tags
+                    pass
 
         return nb_params
 


### PR DESCRIPTION
For cases where there is an Exception thrown when trying to retrieve device tags, I added in exception handling to ignore the tags and continue processing the vlan creation.

This resolved the issue when I tested it locally, however it does not necessarily resolve the root cause of the issue, which I believe stems from the `device.get_device_tag_id()` method further upstream.