### PR TITLE
Fixing napalm extra args validation

### DIFF
--- a/network_importer/inventory.py
+++ b/network_importer/inventory.py
@@ -82,12 +82,12 @@ class NetworkImporterInventory:
 
                 if not self.global_group.connection_options["napalm"].extras:
                     self.global_group.connection_options["napalm"].extras = {"optional_args": {"secret": self.password}}
-                elif isinstance(dict, self.global_group.connection_options["napalm"].extras):
+                elif isinstance(self.global_group.connection_options["napalm"].extras, dict):
                     if "optional_args" not in self.global_group.connection_options["napalm"].extras:
                         self.global_group.connection_options["napalm"].extras["optional_args"] = {
                             "secret": self.password
                         }
-                    elif isinstance(dict, self.global_group.connection_options["napalm"].extras["optional_args"]):
+                    elif isinstance(self.global_group.connection_options["napalm"].extras["optional_args"], dict):
                         self.global_group.connection_options["napalm"].extras["optional_args"]["secret"] = self.password
 
 


### PR DESCRIPTION
fixes #291


Trying to pass napalm specific options using **[network.napalm_extras]** in the network_importer.toml file, throws the following error:

```bash
Traceback (most recent call last):
  File "/usr/local/bin/network-importer", line 8, in <module>
    sys.exit(main())
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/usr/local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/usr/local/lib/python3.7/site-packages/network_importer/cli.py", line 104, in apply
    ni.build_inventory(limit=limit)
  File "/usr/local/lib/python3.7/site-packages/network_importer/performance.py", line 67, in timed
    result = method(*args, **kw)
  File "/usr/local/lib/python3.7/site-packages/network_importer/main.py", line 70, in build_inventory
    "settings": config.SETTINGS.inventory.settings,
  File "/usr/local/lib/python3.7/site-packages/nornir/init_nornir.py", line 72, in InitNornir
    inventory=load_inventory(config),
  File "/usr/local/lib/python3.7/site-packages/nornir/init_nornir.py", line 20, in load_inventory
    inv = inventory_plugin(**config.inventory.options).load()
  File "/usr/local/lib/python3.7/site-packages/network_importer/adapters/nautobot_api/inventory.py", line 27, in __init__
    *args, **kwargs,
  File "/usr/local/lib/python3.7/site-packages/network_importer/inventory.py", line 85, in __init__
    elif isinstance(dict, self.global_group.connection_options["napalm"].extras):
TypeError: isinstance() arg 2 must be a type or tuple of types
```

It seems the problem is the code in the exactly the highlighted line: https://github.com/networktocode/network-importer/blob/9e366247bfd05af0b872e76d938777cf9c5ff44b/network_importer/inventory.py#L85

isintance() should receive the object first and the type we are trying to assess as a second argument. That order is inverted and `dict` is passed as the first argument, whereas `self.global_group.connection_options["napalm"].extras` is the second. 

I can see the same thing happening in line 90 again, by the way.