### PR TITLE
replace non-alphanumeric chars in device_tag slug with underscore

### DIFF
--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -48,9 +48,9 @@ class NautobotDevice(Device):
             return self.device_tag_id
 
         tag = self.diffsync.nautobot.extras.tags.get(name=f"device={self.name}")
-
         if not tag:
-            tag = self.diffsync.nautobot.extras.tags.create(name=f"device={self.name}", slug=f"device__{self.name}")
+            tag = self.diffsync.nautobot.extras.tags.create(
+                name=f"device={self.name}", slug=''.join(c if c.isalnum() else '_' for c in self.name))
 
         self.device_tag_id = tag.id
         return self.device_tag_id

--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -50,7 +50,8 @@ class NautobotDevice(Device):
         tag = self.diffsync.nautobot.extras.tags.get(name=f"device={self.name}")
         if not tag:
             tag = self.diffsync.nautobot.extras.tags.create(
-                name=f"device={self.name}", slug=''.join(c if c.isalnum() else '_' for c in self.name))
+                name=f"device={self.name}",
+                slug=f"device__{''.join(c if c.isalnum() else '_' for c in self.name)}")
 
         self.device_tag_id = tag.id
         return self.device_tag_id


### PR DESCRIPTION
Fixes a traceback when the configured hostname on a device includes non-alphanumeric characters (eg, hostname configured to fqdn)