### PR TITLE
If interface-mode doesnt isnt set but there are tagged vlans - set the tagged nautobot attribute

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+To use this local branch:
+git clone this repo
+pip install network-importer/
+
 # Network Importer
 
 The network importer is a tool/library to analyze and/or synchronize an existing network with a Network Source of Truth (SOT), it's designed to be idempotent and by default it's only showing the difference between the running network and the remote SOT.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 To use this local branch:
+```
 git clone this repo
-pip install network-importer/
 
+pip install network-importer/
+```
 # Network Importer
 
 The network importer is a tool/library to analyze and/or synchronize an existing network with a Network Source of Truth (SOT), it's designed to be idempotent and by default it's only showing the difference between the running network and the remote SOT.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 To use this local branch:
 ```
-git clone this repo
+git clone git@github.com:craigcpj/network-importer.git
 
 pip install network-importer/
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 To use this local branch:
 ```
-git clone git@github.com:craigcpj/network-importer.git
-
+git clone https://github.com/craigcpj/network-importer.git
 pip install network-importer/
 ```
 # Network Importer

--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -124,8 +124,8 @@ class NautobotInterface(Interface):
         elif "switchport_mode" in attrs and attrs["switchport_mode"] == "TRUNK":
             nb_params["mode"] = "tagged"
         elif ("switchport_mode" in attrs and attrs["switchport_mode"] == "NONE") and attrs["mode"] == "L3_SUB_VLAN":
-            LOGGER.warning("NB_PARAMS: %s", nb_params)
-            LOGGER.warning("ATTRS: %s", attrs)
+            LOGGER.info("NB_PARAMS: %s", nb_params)
+            LOGGER.info("ATTRS: %s", attrs)
             nb_params["mode"] = "tagged"
 
         # if is None:

--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -655,11 +655,12 @@ class NautobotCable(Cable):
             )
             if not interface_a:
                 LOGGER.info(
-                    "Unable to create Cable %s in %s, unable to find the interface %s %s",
+                    "CABLE: Unable to create Cable %s in %s, unable to find the interface %s %s %s",
                     item.get_unique_id(),
                     diffsync.name,
                     ids["device_a_name"],
                     ids["interface_a_name"],
+                    item,
                 )
                 return item
 

--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -123,6 +123,10 @@ class NautobotInterface(Interface):
             nb_params["mode"] = "access"
         elif "switchport_mode" in attrs and attrs["switchport_mode"] == "TRUNK":
             nb_params["mode"] = "tagged"
+        elif ("switchport_mode" in attrs and attrs["switchport_mode"] == "NONE") and attrs["mode"] == "L3_SUB_VLAN":
+            LOGGER.warning("NB_PARAMS: %s", nb_params)
+            LOGGER.warning("ATTRS: %s", attrs)
+            nb_params["mode"] = "tagged"
 
         # if is None:
         #     intf_properties["enabled"] = intf.active

--- a/network_importer/adapters/network_importer/adapter.py
+++ b/network_importer/adapters/network_importer/adapter.py
@@ -18,6 +18,7 @@ from network_importer.exceptions import AdapterLoadFatalError
 from network_importer.inventory import reachable_devs, valid_and_reachable_devs
 from network_importer.tasks import check_if_reachable, warning_not_reachable
 from network_importer.drivers import dispatcher
+from nornir_napalm.plugins.tasks import napalm_get
 from network_importer.processors.get_neighbors import GetNeighbors, hosts_for_cabling
 from network_importer.processors.get_vlans import GetVlans
 from network_importer.utils import (
@@ -404,9 +405,11 @@ class NetworkImporterAdapter(BaseAdapter):
         for link in p2p_links.frame().itertuples():
 
             if link.Interface.hostname not in device_names:
+                LOGGER.debug("A SIDE DEVICE NOT IN: %s / %s", link.Interface.hostname, device_names)
                 continue
 
             if link.Remote_Interface.hostname not in device_names:
+                LOGGER.debug("Z SIDE DEVICE NOT IN: %s / %s", link.Remote_Interface.hostname, device_names)
                 continue
 
             cable = self.cable(

--- a/network_importer/inventory.py
+++ b/network_importer/inventory.py
@@ -13,7 +13,7 @@ class NetworkImporterHost(Host):
     site_name: Optional[str]
     """Name of the site this device belong to."""
 
-    is_reacheable: Optional[bool]
+    is_reachable: Optional[bool] = ""
     """Global Flag to indicate if we are able to connect to a device"""
 
     status: Optional[str] = "ok"


### PR DESCRIPTION
flexible-vlan-tagging is not being read correctly or at all for routers.  Switches with interface-mode trunk do have interfaces set as tagged, however Routers with flexible-vlan-tagging cannot import into Nautobot.

I added a work around so that if it cannot find interface-mode trunk/access but it finds tagged vlans, to set the nautobot field "mode" to "tagged"