### PR TITLE
added mode L3_SUB_VLAN as tagged

### DIFF
--- a/network_importer/adapters/nautobot_api/models.py
+++ b/network_importer/adapters/nautobot_api/models.py
@@ -124,6 +124,8 @@ class NautobotInterface(Interface):
             nb_params["mode"] = "access"
         elif "switchport_mode" in attrs and attrs["switchport_mode"] == "TRUNK":
             nb_params["mode"] = "tagged"
+        elif "mode" in attrs and attrs["mode"] == "L3_SUB_VLAN":
+            nb_params["mode"] = "tagged"
 
         # if is None:
         #     intf_properties["enabled"] = intf.active


### PR DESCRIPTION
Working with Jeremy White at the NANOG88 hackathon June 11, 2023, we identified a few issues with adapters/nautobot_api/models.py in the network-importer instance I had installed a few months before on February 9.  The Vlan tag creation issue was solved with `slugify(self.name)` but it seems to have been fixed in develop on Feb. 2 with this:

```
tag = self.diffsync.nautobot.extras.tags.create(
                name=f"device={self.name}", slug=f"device__{''.join(c if c.isalnum() else '_' for c in self.name)}"
            )
```

As a result, I'm only including the L3_SUB_VLAN tagged mode fix.